### PR TITLE
Fix deprecated calcNumThresholded in convert_octomap.cpp

### DIFF
--- a/motion_estimate/src/create_octomap/convert_octomap.cpp
+++ b/motion_estimate/src/create_octomap/convert_octomap.cpp
@@ -105,7 +105,12 @@ OcTree* ConvertOctomap::convertPointCloudToOctree(pronto::PointCloud* &cloud){
 
   // Additional work:
   unsigned int numThresholded, numOther;
-  tree->calcNumThresholdedNodes(numThresholded, numOther);
+  for (OcTree::tree_iterator it = tree->begin_tree(), end = tree->end_tree(); it != end; ++it) {
+    if (tree->isNodeAtThreshold(*it))
+      ++numThresholded;
+    else
+      ++numOther;
+  }
 
   std::cout << "Full tree\n" << "===========================\n";
   cout << "Tree size: " << tree->size() <<" nodes (" <<numThresholded <<" thresholded, "<< numOther << " other)\n";
@@ -120,7 +125,12 @@ OcTree* ConvertOctomap::convertPointCloudToOctree(pronto::PointCloud* &cloud){
 
   std::cout << "Pruned tree (lossless compression)\n" << "===========================\n";
   tree->prune();
-  tree->calcNumThresholdedNodes(numThresholded, numOther);
+  for (OcTree::tree_iterator it = tree->begin_tree(), end = tree->end_tree(); it != end; ++it) {
+    if (tree->isNodeAtThreshold(*it))
+      ++numThresholded;
+    else
+      ++numOther;
+  }
   memUsage = tree->memoryUsage();
 
   cout << "Tree size: " << tree->size() <<" nodes (" <<numThresholded<<" thresholded, "<< numOther << " other)\n";
@@ -132,7 +142,12 @@ OcTree* ConvertOctomap::convertPointCloudToOctree(pronto::PointCloud* &cloud){
   std::cout << "Pruned max-likelihood tree (lossy compression)\n" << "===========================\n";
   tree->toMaxLikelihood();
   tree->prune();
-  tree->calcNumThresholdedNodes(numThresholded, numOther);
+  for (OcTree::tree_iterator it = tree->begin_tree(), end = tree->end_tree(); it != end; ++it) {
+    if (tree->isNodeAtThreshold(*it))
+      ++numThresholded;
+    else
+      ++numOther;
+  }
   memUsage = tree->memoryUsage();
   cout << "Tree size: " << tree->size() <<" nodes (" <<numThresholded<<" thresholded, "<< numOther << " other)\n";
   cout << "Memory: " << memUsage << " byte (" << memUsage/(1024.*1024.) << " MB)" << endl;


### PR DESCRIPTION
In order to make pronto compatible with octomap versions newer than v1.5, convert_octomap.cpp needs to be fixed. This fix has been tested with v1.7.0 and should be backwards compatible.

Relates to https://github.com/openhumanoids/main-distro/issues/2067

cc: @mauricefallon 