### PR TITLE
Implemented yaw and orientation modes for vicon

### DIFF
--- a/mav/mav-state-estimator/src/mav_state_est/mav_state_est.cpp
+++ b/mav/mav-state-estimator/src/mav_state_est/mav_state_est.cpp
@@ -27,40 +27,57 @@ MavStateEstimator::~MavStateEstimator()
 
 void MavStateEstimator::addUpdate(RBISUpdateInterface * update, bool roll_forward)
 {
+    // Add current update to history
   updateHistory::historyMapIterator added_it = history.addToHistory(update);
 
+  // If there are no unprocessed updates other than the current one,
+  // the current one only is where the "unprocessed" queue starts
   if (unprocessed_updates_start == history.updateMap.end() ||
       added_it->first < unprocessed_updates_start->first) {
     unprocessed_updates_start = added_it;
   }
+  // If we don't want to process, we exit
   if (!roll_forward) {
     return;
   }
 
+  // We get the update before the first unprocessed update
   updateHistory::historyMapIterator prev_it = unprocessed_updates_start;
-  prev_it--;
+  --prev_it;
+  // We get the first unprocessed update. It could be just the last update.
   updateHistory::historyMapIterator current_it = unprocessed_updates_start;
+
   //  fprintf(stderr, "roll forward: %s ", RBISUpdateInterface::sensor_enum_strings[prev_it->second->sensor_id]);
+
+  // Iterate over unprocessed updates
   while (current_it != history.updateMap.end()) {
     RBISUpdateInterface * current_update = current_it->second;
     RBISUpdateInterface * prev_update = prev_it->second;
-    current_update->updateFilter(prev_update->posterior_state, prev_update->posterior_covariance, prev_update->loglikelihood);
+
+    // The prior is the previous posterior
+    current_update->updateFilter(prev_update->posterior_state,
+                                 prev_update->posterior_covariance,
+                                 prev_update->loglikelihood);
+
+    // We update the time for the current posterior
     current_update->posterior_state.utime = current_update->utime;
 
-//    if (current_update->posterior_state.hasNan()){
-//      fprintf(stderr,"ERROR: %s Update Made state NAN!\n", RBISUpdateInterface::sensor_enum_strings[current_update->sensor_id]);
-//    }
+    // if (current_update->posterior_state.hasNan()){
+    //   fprintf(stderr,"ERROR: %s Update Made state NAN!\n", RBISUpdateInterface::sensor_enum_strings[current_update->sensor_id]);
+    // }
 
-  //    fprintf(stderr, "->%s  ", RBISUpdateInterface::sensor_enum_strings[current_update->sensor_id]);
+    // fprintf(stderr, "->%s  ", RBISUpdateInterface::sensor_enum_strings[current_update->sensor_id]);
     prev_it = current_it;
     current_it++;
   }
   //  fprintf(stderr, "\n");
 
+  // The newest time is the previous iterator, cause the current is end()
   int64_t newest_utime = prev_it->first;
   int64_t oldest_utime = newest_utime - this->utime_history_span;
+  // We resize the history
   history.clearHistoryBeforeUtime(oldest_utime);
-  //we've rolled forward
+  // We've rolled forward
   unprocessed_updates_start = history.updateMap.end();
 }
 

--- a/mav/mav-state-estimator/src/mav_state_est/sensor_handlers.cpp
+++ b/mav/mav-state-estimator/src/mav_state_est/sensor_handlers.cpp
@@ -4,10 +4,15 @@ using namespace Eigen;
 
 namespace MavStateEst {
 
-InsHandler::InsHandler(BotParam * _param, BotFrames * _frames)
-{
-  // mfallon: this chooses between MICROSTRAIN and ATLAS_IMU_BATCH
-  channel = bot_param_get_str_or_fail(_param, "state_estimator.ins.channel");
+InsHandler::InsHandler(BotParam * _param, BotFrames * _frames) :
+    accel_bias_update(true),
+    gyro_bias_update(true),
+    accel_bias_initial(Eigen::Vector3d::Zero()),
+    gyro_bias_initial(Eigen::Vector3d::Zero()),
+    online_accel_bias_initial(true),
+    online_gyro_bias_initial(true){
+    // mfallon: this chooses between MICROSTRAIN and ATLAS_IMU_BATCH
+    channel = bot_param_get_str_or_fail(_param, "state_estimator.ins.channel");
 
   cov_gyro = bot_param_get_double_or_fail(_param, "state_estimator.ins.q_gyro");
   cov_gyro = bot_sq(bot_to_radians(cov_gyro));
@@ -46,6 +51,48 @@ InsHandler::InsHandler(BotParam * _param, BotFrames * _frames)
   g_vec_sum.setZero();
   mag_vec_sum.setZero();
   gyro_bias_sum.setZero();
+
+  int tmp_int = bot_param_get_boolean_or_fail(_param, "state_estimator.ins.accel_bias_update");
+  accel_bias_update = (tmp_int == 0 ? false : true);
+
+  double accel_bias_initial_array[3];
+  bot_param_get_double_array_or_fail(_param, "state_estimator.ins.accel_bias_initial", accel_bias_initial_array, 3);
+  accel_bias_initial << accel_bias_initial_array[0], accel_bias_initial_array[1], accel_bias_initial_array[2];
+  std::cout << "Setting initial accel bias to: " << accel_bias_initial.transpose() << std::endl;
+  std::cout << "INS set to ";
+  std::cout << (accel_bias_update ? "" : "NOT");
+  std::cout << "update accel bias" << std::endl;
+  // If we don't want to update the bias, the covariance must be 0
+  if(!accel_bias_update){
+      cov_accel_bias = 0.0;
+  }
+
+  tmp_int = bot_param_get_boolean_or_fail(_param, "state_estimator.ins.gyro_bias_update");
+  gyro_bias_update = (tmp_int == 0 ? false : true);
+
+  double gyro_bias_initial_array[3];
+  bot_param_get_double_array_or_fail(_param, "state_estimator.ins.gyro_bias_initial", gyro_bias_initial_array, 3);
+  gyro_bias_initial << gyro_bias_initial_array[0], gyro_bias_initial_array[1], gyro_bias_initial_array[2];
+  std::cout << "Setting initial gyro bias to: " << gyro_bias_initial.transpose() << std::endl;
+  std::cout << "INS set to ";
+  std::cout << (gyro_bias_update ? "" : "NOT ");
+  std::cout << "update gyro bias" << std::endl;
+  // If we don't want to update the bias, the covariance must be 0
+  if(!gyro_bias_update){
+      cov_gyro_bias = 0.0;
+  }
+
+  tmp_int = bot_param_get_boolean_or_fail(_param, "state_estimator.ins.online_accel_bias_initial");
+  online_accel_bias_initial = (tmp_int == 0 ? false : true);
+  std::cout << "INS set to ";
+  std::cout << (online_accel_bias_initial ? "" : "NOT ");
+  std::cout << "compute initial accel bias online at the beginning" << std::endl;
+
+  tmp_int = bot_param_get_boolean_or_fail(_param, "state_estimator.ins.online_gyro_bias_initial");
+  online_gyro_bias_initial = (tmp_int == 0 ? false : true);
+  std::cout << "INS set to ";
+  std::cout << (online_gyro_bias_initial ? "" : "NOT ");
+  std::cout << "compute initial gyro bias online at the beginning" << std::endl;
 }
 
 ////////// Typical Micro Strain INS /////////////////
@@ -63,7 +110,25 @@ RBISUpdateInterface * InsHandler::processMessage(const mav::ins_t * msg)
   bot_quat_rotate_to(ins_to_body.rot_quat, msg->gyro, body_gyro);
   Eigen::Map<Eigen::Vector3d> gyro(body_gyro);
 
-  return new RBISIMUProcessStep(gyro, accelerometer, cov_gyro, cov_accel, cov_gyro_bias, cov_accel_bias, dt, msg->utime);
+    RBISIMUProcessStep* update = new RBISIMUProcessStep(gyro,
+            accelerometer,
+            cov_gyro,
+            cov_accel,
+            cov_gyro_bias,
+            cov_accel_bias,
+            dt,
+            msg->utime);
+
+    // We reset the bias values to the original value, if requested
+    if(!gyro_bias_update) {
+        update->posterior_state.gyroBias() = gyro_bias_initial;
+    }
+
+    if(!accel_bias_update) {
+        update->posterior_state.accelBias() = accel_bias_initial;
+    }
+
+    return update;
 }
 
 bool InsHandler::processMessageInit(const mav::ins_t * msg,
@@ -281,6 +346,22 @@ bool InsHandler::processMessageInitCommon(const std::map<std::string, bool> & se
       Eigen::Vector3d mag_vec_rpy = bot_to_degrees(eigen_utils::getEulerAngles(quat_mag));
       fprintf(stderr, "Yaw Initialized from INS: %f\n", mag_vec_rpy(2));
     }
+
+    if(online_accel_bias_initial) {
+        std::cout << "Using online estimated accel bias: ";
+        std::cout << init_state.accelBias().transpose() << std::endl;
+        accel_bias_initial = init_state.accelBias();
+    }
+
+    if(online_gyro_bias_initial){
+        std::cout << "Using online estimated gyro bias: ";
+        std::cout << init_state.gyroBias().transpose() << std::endl;
+        gyro_bias_initial = init_state.gyroBias();
+    }
+
+    init_state.gyroBias() = gyro_bias_initial;
+    init_state.accelBias() = accel_bias_initial;
+
     return true;
   }
 }

--- a/mav/mav-state-estimator/src/mav_state_est/sensor_handlers.cpp
+++ b/mav/mav-state-estimator/src/mav_state_est/sensor_handlers.cpp
@@ -418,6 +418,14 @@ ViconHandler::ViconHandler(BotParam * param, BotFrames * frames)
     mode = ViconHandler::MODE_POSITION_ORIENT;
     std::cout << "Vicon will provide position and orientation measurements." << std::endl;
   }
+  else if (strcmp(mode_str, "orientation") == 0) {
+    mode = ViconHandler::MODE_ORIENTATION;
+    std::cout << "Vicon will provide orientation measurements." << std::endl;
+  }
+  else if (strcmp(mode_str, "yaw") == 0) {
+    mode = ViconHandler::MODE_YAW;
+    std::cout << "Vicon will provide yaw orientation measurements." << std::endl;
+  }
   else {
     mode = ViconHandler::MODE_POSITION;
     std::cout << "Unrecognized Vicon mode. Using position mode by default." << std::endl;
@@ -451,8 +459,17 @@ void ViconHandler::init(BotParam * param)
 
   if (mode == MODE_POSITION) {
     z_indices = RBIS::positionInds();
-  }
-  else {
+  } else if (mode == MODE_YAW){
+      z_indices.resize(1);
+      z_indices(0) = RBIS::chi_ind + 2; // z component only
+      cov_vicon.resize(1,1);
+      cov_vicon(0,0) = pow(bot_to_radians(r_vicon_chi), 2);
+  } else if (mode == MODE_ORIENTATION){
+      z_indices.resize(3);
+      z_indices = RBIS::chiInds();
+      cov_vicon.resize(3,3);
+      cov_vicon = pow(bot_to_radians(r_vicon_chi), 2) * Eigen::Matrix3d::Identity();
+  } else {
     z_indices.resize(6);
     z_indices.head<3>() = RBIS::positionInds();
     z_indices.tail<3>() = RBIS::chiInds();
@@ -481,19 +498,44 @@ RBISUpdateInterface * ViconHandler::processMessage(const bot_core::rigid_transfo
     return NULL;
 
   if (mode == MODE_POSITION) {
-    return new RBISIndexedMeasurement(z_indices, Eigen::Map<const Eigen::Vector3d>( local_to_body.trans_vec ),
-        cov_vicon.block<3, 3>(0, 0), RBISUpdateInterface::vicon,
-        utime);
-  }
-  else {
-    Eigen::VectorXd z_meas(6);
-    Eigen::Quaterniond quat;
-    eigen_utils::botDoubleToQuaternion(quat, local_to_body.rot_quat );
+      return new RBISIndexedMeasurement(z_indices, Eigen::Map<const Eigen::Vector3d>( local_to_body.trans_vec ),
+                                        cov_vicon,RBISUpdateInterface::vicon, msg->utime);
+  } else if(mode == MODE_YAW) {
 
-    z_meas.head<3>() = Eigen::Map<const Eigen::Vector3d>(local_to_body.trans_vec);
+      Eigen::VectorXd z_meas(1);
+      Eigen::Quaterniond quat;
+      eigen_utils::botDoubleToQuaternion(quat, local_to_body.rot_quat);
 
-    return new RBISIndexedPlusOrientationMeasurement(z_indices, z_meas, cov_vicon, quat, RBISUpdateInterface::vicon,
-        utime);
+      return new RBISIndexedPlusOrientationMeasurement(z_indices,
+                                                       z_meas,
+                                                       cov_vicon,
+                                                       quat,
+                                                       RBISUpdateInterface::vicon,
+                                                       msg->utime);
+  }  else if(mode == MODE_ORIENTATION){
+      Eigen::VectorXd z_meas(3);
+      Eigen::Quaterniond quat;
+      eigen_utils::botDoubleToQuaternion(quat, local_to_body.rot_quat);
+
+      return new RBISIndexedPlusOrientationMeasurement(z_indices,
+                                                       z_meas,
+                                                       cov_vicon,
+                                                       quat,
+                                                       RBISUpdateInterface::vicon,
+                                                       msg->utime);
+  }  else if(mode == MODE_POSITION_ORIENT){
+      Eigen::VectorXd z_meas(6);
+      Eigen::Quaterniond quat;
+      eigen_utils::botDoubleToQuaternion(quat, local_to_body.rot_quat );
+
+      z_meas.head<3>() = Eigen::Map<const Eigen::Vector3d>(local_to_body.trans_vec);
+
+      return new RBISIndexedPlusOrientationMeasurement(z_indices,
+                                                       z_meas,
+                                                       cov_vicon,
+                                                       quat,
+                                                       RBISUpdateInterface::vicon,
+                                                       utime);
   }
 }
 

--- a/mav/mav-state-estimator/src/mav_state_est/sensor_handlers.hpp
+++ b/mav/mav-state-estimator/src/mav_state_est/sensor_handlers.hpp
@@ -23,6 +23,13 @@ namespace MavStateEst {
 
 class InsHandler {
 protected:
+  bool accel_bias_update;
+  bool gyro_bias_update;
+  Eigen::Vector3d accel_bias_initial;
+  Eigen::Vector3d gyro_bias_initial;
+  bool online_accel_bias_initial;
+  bool online_gyro_bias_initial;
+
   void create(BotParam * _param, BotFrames * _frames);
   public:
   InsHandler(BotParam * _param, BotFrames * _frames);

--- a/mav/mav-state-estimator/src/mav_state_est/sensor_handlers.hpp
+++ b/mav/mav-state-estimator/src/mav_state_est/sensor_handlers.hpp
@@ -98,7 +98,7 @@ protected:
 class ViconHandler {
 public:
   typedef enum {
-    MODE_POSITION, MODE_POSITION_ORIENT
+    MODE_POSITION, MODE_POSITION_ORIENT, MODE_ORIENTATION, MODE_YAW
   } ViconMode;
 
   ViconHandler(BotParam * param, BotFrames *frames);


### PR DESCRIPTION
With this improvement you can select `yaw` and `orientation` in the config file to have yaw and orientation only corrections from vicon.