### PR TITLE
Implmented vicon yaw and orientation modes

### DIFF
--- a/state-estimator/src/mav_state_est/sensor_handlers.hpp
+++ b/state-estimator/src/mav_state_est/sensor_handlers.hpp
@@ -89,7 +89,7 @@ protected:
 class ViconHandler {
 public:
   typedef enum {
-    MODE_POSITION, MODE_POSITION_ORIENT
+    MODE_POSITION, MODE_POSITION_ORIENT, MODE_ORIENTATION, MODE_YAW
   } ViconMode;
 
   ViconHandler(BotParam * param, BotFrames *frames);


### PR DESCRIPTION
You can now use vicon in yaw mode and in orientation mode. Just put `yaw` or `orientation` in the corresponding param in the param file