### PR TITLE
removes requirements for BDI orientation estimate for both Val and Atlas

### DIFF
--- a/motion_estimate/scripts/state-sync-simple.py
+++ b/motion_estimate/scripts/state-sync-simple.py
@@ -19,14 +19,14 @@ sys.path.append(home_dir + "/software/build/lib/python2.7/site-packages")
 sys.path.append(home_dir + "/software/build/lib/python2.7/dist-packages")
 
 from bot_core.pose_t import pose_t
-from pronto.robot_state_t import robot_state_t
-from pronto.joint_state_t import joint_state_t
-from pronto.vector_3d_t import vector_3d_t
-from pronto.position_3d_t import position_3d_t
-from pronto.twist_t import twist_t
-from pronto.quaternion_t import quaternion_t
-from pronto.twist_t import twist_t
-from pronto.force_torque_t import force_torque_t
+from bot_core.robot_state_t import robot_state_t
+from bot_core.joint_state_t import joint_state_t
+from bot_core.vector_3d_t import vector_3d_t
+from bot_core.position_3d_t import position_3d_t
+from bot_core.twist_t import twist_t
+from bot_core.quaternion_t import quaternion_t
+from bot_core.twist_t import twist_t
+from bot_core.force_torque_t import force_torque_t
 
 ########################################################################################
 def timestamp_now (): return int (time.time () * 1000000)

--- a/motion_estimate/src/gpf-rgbd-lib/rbis_gpf_update.cpp
+++ b/motion_estimate/src/gpf-rgbd-lib/rbis_gpf_update.cpp
@@ -70,7 +70,7 @@ RgbdGPFHandler::RgbdGPFHandler(lcm_t * lcm, BotParam * param, BotFrames * frames
 
 }
 
-RBISUpdateInterface * RgbdGPFHandler::processMessage(const kinect::frame_msg_t * msg)
+RBISUpdateInterface * RgbdGPFHandler::processMessage(const kinect::frame_msg_t * msg, RBIS state, RBIM cov)
 {
 //  if (counter++ % downsample_factor != 0)
 //    return NULL;

--- a/motion_estimate/src/gpf-rgbd-lib/rbis_gpf_update.hpp
+++ b/motion_estimate/src/gpf-rgbd-lib/rbis_gpf_update.hpp
@@ -31,7 +31,7 @@ class RgbdGPFHandler {
 public:
   RgbdGPFHandler(lcm_t * lcm, BotParam * param, BotFrames * frames);
 
-  RBISUpdateInterface * processMessage(const kinect::frame_msg_t * msg);
+  RBISUpdateInterface * processMessage(const kinect::frame_msg_t * msg, RBIS state, RBIM cov);
 
   lcm_t * lcm_pub; //needed to copy into update each time to publish message for debugging
   std::string pub_channel;

--- a/motion_estimate/src/leg_estimate/LegOdoWrapper.cpp
+++ b/motion_estimate/src/leg_estimate/LegOdoWrapper.cpp
@@ -56,9 +56,6 @@ void LegOdoWrapper::setupLegOdo() {
   }
 
   leg_est_ = new leg_estimate(lcm_publish_, botparam_, model_);
-  std::string leg_odo_mode = bot_param_get_str_or_fail(botparam_, "state_estimator.legodo_driven_process.integration_mode");
-  std::cout << "Overwriting the leg odom mode:: " << leg_odo_mode << "\n";
-  leg_est_->setLegOdometryMode( leg_odo_mode );
 }
 
 void App::poseBDIHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::pose_t* msg){

--- a/motion_estimate/src/leg_estimate/LegOdoWrapper.hpp
+++ b/motion_estimate/src/leg_estimate/LegOdoWrapper.hpp
@@ -43,15 +43,7 @@ protected:
   // bot::frames* frames_cpp_;
 
   bot_core::six_axis_force_torque_array_t force_torque_; // Most recent force torque messurement
-  bool force_torque_init_; // Have we received a force torque message?
-  
-  // Pose BDI:
-  PoseT world_to_body_bdi_full_;  
-  Eigen::Isometry3d world_to_body_bdi_;
-  int64_t prev_bdi_utime_;
-  int64_t body_bdi_init_;  
-  
-  
+  bool force_torque_init_; // Have we received a force torque message?  
   
 };
 
@@ -64,7 +56,6 @@ class App : public LegOdoWrapper {
   private:
     void forceTorqueHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::six_axis_force_torque_array_t* msg);
     void jointStateHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::joint_state_t* msg);
-    void poseBDIHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::pose_t* msg);  
     void viconHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::rigid_transform_t* msg);
 };
 

--- a/motion_estimate/src/leg_estimate/leg_estimate.hpp
+++ b/motion_estimate/src/leg_estimate/leg_estimate.hpp
@@ -65,7 +65,6 @@ class leg_estimate{
     ~leg_estimate(){
     }
     
-    void setPoseBDI(Eigen::Isometry3d bdi_to_body_in ){ bdi_to_body_ = bdi_to_body_in; }
     void setPoseBody(Eigen::Isometry3d world_to_body_in ){ 
       world_to_body_ = world_to_body_in; 
       world_to_body_init_ = true;
@@ -187,11 +186,6 @@ class leg_estimate{
     Eigen::Isometry3d odom_to_primary_foot_fixed_; // Position in the odom frame in which the fixed foot is kept
     Eigen::Isometry3d odom_to_secondary_foot_; // Ditto for moving foot (entirely defined by kinematics)
 
-    // Pelvis Position Estimate produced by BDI. 
-    // Used to calculate position delta by defining pelvis and foot orientation
-    // TODO: use estimated state instead
-    Eigen::Isometry3d bdi_to_body_;
-    
     // Pelvis Position produced by mav-estimator
     // TODO: this should be the same as the RBIS state, currently using LCM to provide this
     Eigen::Isometry3d world_to_body_;

--- a/motion_estimate/src/leg_estimate/leg_estimate.hpp
+++ b/motion_estimate/src/leg_estimate/leg_estimate.hpp
@@ -108,7 +108,6 @@ class leg_estimate{
     
     Eigen::Isometry3d getRunningEstimate(){ return odom_to_body_; }
     
-    void setLegOdometryMode(std::string leg_odometry_mode_in ){ leg_odometry_mode_ = leg_odometry_mode_in; }
     void setInitializationMode(std::string initialization_mode_in ){ initialization_mode_ = initialization_mode_in; }
 
   private:
@@ -126,7 +125,6 @@ class leg_estimate{
 
     /// Parameters
     int verbose_;
-    std::string leg_odometry_mode_;
     // How the position will be initialized
     std::string initialization_mode_;
     // Which link is assumed to be stationary - typically [lr]_foot or [lr]_talus
@@ -166,13 +164,7 @@ class leg_estimate{
     /// Integration Methods:
     bool initializePose(Eigen::Isometry3d body_to_foot);
     bool prepInitialization(Eigen::Isometry3d body_to_l_foot,Eigen::Isometry3d body_to_r_foot, contact_status_id contact_status);
-    // Pure Leg Odometry, no IMU
-    // return: true on initialization, else false
-    bool leg_odometry_basic(Eigen::Isometry3d body_to_l_foot,Eigen::Isometry3d body_to_r_foot, contact_status_id contact_status);
-    // At the moment a foot transition occurs: slave the pelvis pitch and roll and then fix foot using fk.
-    // Dont move or rotate foot after that.
-    // return: true on initialization, else false    
-    bool leg_odometry_gravity_slaved_once(Eigen::Isometry3d body_to_l_foot,Eigen::Isometry3d body_to_r_foot, contact_status_id contact_status);
+
     // Foot position, as with above. For subsequent ticks, foot quaternion is updated using the pelvis quaternion
     // The pelvis position is then backed out using this new foot positon and fk.
     // return: true on initialization, else false    

--- a/motion_estimate/src/mav_est_fovis/rbis_fovis_update.cpp
+++ b/motion_estimate/src/mav_est_fovis/rbis_fovis_update.cpp
@@ -87,7 +87,7 @@ bot_core::pose_t getBotTransAsBotPoseVelocity(BotTrans bt, int64_t utime ){
   return pose;
 }
 
-RBISUpdateInterface * FovisHandler::processMessage(const fovis::update_t * msg){
+RBISUpdateInterface * FovisHandler::processMessage(const fovis::update_t * msg, RBIS state, RBIM cov){
   
   if (msg->estimate_status == fovis::update_t::ESTIMATE_VALID){
     std::cout << "FovisHandler: FOVIS success\n";

--- a/motion_estimate/src/mav_est_fovis/rbis_fovis_update.hpp
+++ b/motion_estimate/src/mav_est_fovis/rbis_fovis_update.hpp
@@ -23,7 +23,7 @@ public:
   FovisHandler(lcm::LCM* lcm_recv,  lcm::LCM* lcm_pub,
                BotParam * param);
 
-  RBISUpdateInterface * processMessage(const fovis::update_t  * msg);
+  RBISUpdateInterface * processMessage(const fovis::update_t  * msg, RBIS state, RBIM cov);
 
   FovisMode mode;
   Eigen::VectorXi z_indices;

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_external_update.cpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_external_update.cpp
@@ -14,7 +14,7 @@ LegOdoExternalHandler::LegOdoExternalHandler(lcm::LCM* lcm_recv, lcm::LCM* lcm_p
 }
 
 
-RBISUpdateInterface * LegOdoExternalHandler::processMessage(const pronto::pose_transform_t * msg)
+RBISUpdateInterface * LegOdoExternalHandler::processMessage(const pronto::pose_transform_t * msg, RBIS state, RBIM cov)
 {
   /// ... insert handling and special cases here.
   bool verbose = false;

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_external_update.hpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_external_update.hpp
@@ -17,7 +17,7 @@ public:
   
   LegOdoExternalHandler(lcm::LCM* lcm_recv,  lcm::LCM* lcm_pub, BotParam * param);
 
-  RBISUpdateInterface * processMessage(const pronto::pose_transform_t  * msg);
+  RBISUpdateInterface * processMessage(const pronto::pose_transform_t  * msg, RBIS state, RBIM cov);
 
   lcm::LCM* lcm_pub;
   lcm::LCM* lcm_recv;

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_update.cpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_update.cpp
@@ -211,7 +211,7 @@ void LegOdoHandler::forceTorqueHandler(const lcm::ReceiveBuffer* rbuf, const std
 
 // TODO: Create Legacy ATLAS_STATE handler
 
-RBISUpdateInterface * LegOdoHandler::processMessage(const bot_core::joint_state_t *msg){
+RBISUpdateInterface * LegOdoHandler::processMessage(const bot_core::joint_state_t *msg, RBIS state, RBIM cov){
   
   if (!bdi_init_){
     std::cout << "POSE_BDI not received yet, not integrating leg odometry =========================\n";

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
@@ -89,14 +89,6 @@ public:
   int n_control_contacts_left_;
   int n_control_contacts_right_;
 
-
-  // To locally integrate - to denoise
-  Eigen::Isometry3d local_accum_;
-  bool local_integration_;
-  int local_max_count_;
-  int local_counter_;
-  int64_t local_prev_utime_; 
-
 };
 
 

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
@@ -38,7 +38,7 @@ public:
 
   LegOdoHandler(lcm::LCM* lcm_recv,  lcm::LCM* lcm_pub, 
       BotParam * param, ModelClient* model, BotFrames * frames);
-  RBISUpdateInterface * processMessage(const bot_core::joint_state_t *msg);
+  RBISUpdateInterface * processMessage(const bot_core::joint_state_t *msg, RBIS state, RBIM cov);
 
 
   // Classes:

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
@@ -48,7 +48,6 @@ public:
   LegOdoCommon* leg_odo_common_;
 
   // Ancillary handlers
-  void poseBDIHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::pose_t* msg);  
   void poseBodyHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::pose_t* msg);  
   void viconHandler(const lcm::ReceiveBuffer* rbuf, const std::string& channel, const  bot_core::rigid_transform_t* msg);  
   void republishHandler (const lcm::ReceiveBuffer* rbuf, const std::string& channel);
@@ -81,11 +80,7 @@ public:
   Eigen::Isometry3d prev_worldvicon_to_body_vicon_;
   int64_t prev_vicon_utime_;
 
-  PoseT bdi_to_body_full_;  // POSE_BDI
-  bool bdi_init_; // Have we received POSE_BDI. TODO: add a constructor to PoseT to store this
-
   PoseT world_to_body_full_;  // POSE_BODY NB: this is whats calculated by the
-  bool body_init_; // Have we received POSE_BDI. TODO: add a constructor to PoseT to store this
 
   bot_core::six_axis_force_torque_array_t force_torque_; // Most recent force torque messurement
   bool force_torque_init_; // Have we received a force torque message?

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
@@ -65,6 +65,8 @@ public:
   BotFrames* frames;
   
   // Settings 
+  // Number of iterations to assume are zero velocity at start:
+  int zero_initial_velocity;
   // Republish certain incoming messages, so as to produced output logs
   bool republish_incoming_poses_;
   // Publish Debug Data e.g. kinematic velocities and foot contacts

--- a/motion_estimate/src/pose_meas/pose_meas.cpp
+++ b/motion_estimate/src/pose_meas/pose_meas.cpp
@@ -53,7 +53,7 @@ void PoseMeasHandler::init(BotParam * param)
   }
 }
 
-RBISUpdateInterface * PoseMeasHandler::processMessage(const bot_core::pose_t * msg)
+RBISUpdateInterface * PoseMeasHandler::processMessage(const bot_core::pose_t * msg, RBIS state, RBIM cov)
 {
   // If we have created no_corrections, go silent afterwards
   no_corrections--;

--- a/motion_estimate/src/pose_meas/pose_meas.hpp
+++ b/motion_estimate/src/pose_meas/pose_meas.hpp
@@ -21,7 +21,7 @@ public:
   PoseMeasHandler(BotParam * param, BotFrames *frames);
   PoseMeasHandler(BotParam * param, PoseMeasMode pose_meas_mode);
   void init(BotParam * param);
-  RBISUpdateInterface * processMessage(const bot_core::pose_t * msg);
+  RBISUpdateInterface * processMessage(const bot_core::pose_t * msg, RBIS state, RBIM cov);
   bool processMessageInit(const bot_core::pose_t * msg, const std::map<std::string, bool> & sensors_initialized
         , const RBIS & default_state, const RBIM & default_cov,
         RBIS & init_state, RBIM & init_cov);

--- a/state-estimator/src/gpf/rbis_gpf_update.cpp
+++ b/state-estimator/src/gpf/rbis_gpf_update.cpp
@@ -89,13 +89,13 @@ LaserGPFHandler::LaserGPFHandler(lcm_t * lcm, BotParam * param, BotFrames * fram
   free(laser_chan);
 }
 
-RBISUpdateInterface * LaserGPFHandler::processMessage(const bot_core::planar_lidar_t * msg)
+RBISUpdateInterface * LaserGPFHandler::processMessage(const bot_core::planar_lidar_t * msg, RBIS state, RBIM cov)
 {
   bot_core::planar_lidar_t * msg_cpy = new bot_core::planar_lidar_t(*msg);
   return new RBISLaserGPFMeasurement(gpf, msg_cpy, msg->utime, lcm_pub, pub_channel);
 }
 
-RBISUpdateInterface * LaserGPFHandler::processMessagePointcloud(const bot_core::pointcloud_t * msg)
+RBISUpdateInterface * LaserGPFHandler::processMessagePointcloud(const bot_core::pointcloud_t * msg, RBIS state, RBIM cov)
 {
   bot_core::pointcloud_t * msg_cpy = new bot_core::pointcloud_t(*msg);
   return new RBISLaserGPFMeasurement(gpf, msg_cpy, msg->utime, lcm_pub, pub_channel);

--- a/state-estimator/src/gpf/rbis_gpf_update.hpp
+++ b/state-estimator/src/gpf/rbis_gpf_update.hpp
@@ -34,8 +34,8 @@ class LaserGPFHandler {
 public:
   LaserGPFHandler(lcm_t * lcm, BotParam * _param, BotFrames * _frames);
 
-  RBISUpdateInterface * processMessage(const bot_core::planar_lidar_t * msg);
-  RBISUpdateInterface * processMessagePointcloud(const bot_core::pointcloud_t * msg);
+  RBISUpdateInterface * processMessage(const bot_core::planar_lidar_t * msg, RBIS state, RBIM cov);
+  RBISUpdateInterface * processMessagePointcloud(const bot_core::pointcloud_t * msg, RBIS state, RBIM cov);
 
   lcm_t * lcm_pub; //needed to copy into update each time to publish message for debugging
   std::string pub_channel;

--- a/state-estimator/src/mav_state_est/rbis_initializer.cpp
+++ b/state-estimator/src/mav_state_est/rbis_initializer.cpp
@@ -174,7 +174,7 @@ bool InitMessageHandler::processMessageInit(const pronto::filter_state_t * msg,
  * When subscribed as a normal sensor, the reset message will reset the state estimator
  * on the fly.
  */
-RBISUpdateInterface * InitMessageHandler::processMessage(const pronto::filter_state_t * msg)
+RBISUpdateInterface * InitMessageHandler::processMessage(const pronto::filter_state_t * msg, RBIS state, RBIM cov)
 {
   Eigen::Map<const MatrixXd> cov_map(&msg->cov[0], msg->num_states, msg->num_states);
   RBIM init_cov = cov_map;

--- a/state-estimator/src/mav_state_est/rbis_initializer.hpp
+++ b/state-estimator/src/mav_state_est/rbis_initializer.hpp
@@ -41,7 +41,7 @@ public:
       const std::map<std::string, bool> & sensors_initialized, const RBIS & default_state,
       const RBIM & default_cov, RBIS & init_state, RBIM & init_cov);
 
-  RBISUpdateInterface * processMessage(const pronto::filter_state_t * msg);
+  RBISUpdateInterface * processMessage(const pronto::filter_state_t * msg, RBIS state, RBIM cov);
 };
 
 class RBISInitializer {

--- a/state-estimator/src/mav_state_est/sensor_handlers.hpp
+++ b/state-estimator/src/mav_state_est/sensor_handlers.hpp
@@ -29,12 +29,12 @@ protected:
   std::string channel;
 
   // Microstrain Functions:
-  RBISUpdateInterface * processMessage(const bot_core::ins_t * msg);
+  RBISUpdateInterface * processMessage(const bot_core::ins_t * msg, RBIS state, RBIM cov);
   bool processMessageInit(const bot_core::ins_t * msg, const std::map<std::string, bool> & sensors_initialized
       , const RBIS & default_state, const RBIM & default_cov, RBIS & init_state, RBIM & init_cov);
 
   // Compariable Atlas Functions:
-  RBISUpdateInterface * processMessageAtlas(const bot_core::kvh_raw_imu_batch_t * msg);
+  RBISUpdateInterface * processMessageAtlas(const bot_core::kvh_raw_imu_batch_t * msg, RBIS state, RBIM cov);
   bool processMessageInitAtlas(const bot_core::kvh_raw_imu_batch_t * msg, const std::map<std::string, bool> & sensors_initialized
       , const RBIS & default_state, const RBIM & default_cov, RBIS & init_state, RBIM & init_cov);
   //////////// Members Particular to Atlas:
@@ -74,11 +74,12 @@ protected:
   Eigen::Vector3d gyro_bias_sum;
 };
 
+
 class GpsHandler {
 protected:
   public:
   GpsHandler(BotParam * _param);
-  RBISUpdateInterface * processMessage(const bot_core::gps_data_t * msg);
+  RBISUpdateInterface * processMessage(const bot_core::gps_data_t * msg, RBIS state, RBIM cov);
   bool processMessageInit(const bot_core::gps_data_t * msg, const std::map<std::string, bool> & sensors_initialized
       , const RBIS & default_state, const RBIM & default_cov,
       RBIS & init_state, RBIM & init_cov);
@@ -95,7 +96,7 @@ public:
   ViconHandler(BotParam * param, BotFrames *frames);
   ViconHandler(BotParam * param, ViconMode vicon_mode);
   void init(BotParam * param);
-  RBISUpdateInterface * processMessage(const bot_core::rigid_transform_t * msg);
+  RBISUpdateInterface * processMessage(const bot_core::rigid_transform_t * msg, RBIS state, RBIM cov);
   bool processMessageInit(const bot_core::rigid_transform_t * msg, const std::map<std::string, bool> & sensors_initialized
         , const RBIS & default_state, const RBIM & default_cov,
         RBIS & init_state, RBIM & init_cov);
@@ -117,7 +118,7 @@ public:
   {
       indexed_sensor = this_sensor;
   }
-  RBISUpdateInterface * processMessage(const pronto::indexed_measurement_t * msg);
+  RBISUpdateInterface * processMessage(const pronto::indexed_measurement_t * msg, RBIS state, RBIM cov);
   bool processMessageInit(const pronto::indexed_measurement_t * msg, const std::map<std::string, bool> & sensors_initialized
         , const RBIS & default_state, const RBIM & default_cov,
         RBIS & init_state, RBIM & init_cov);
@@ -134,7 +135,7 @@ public:
   } ScanMatchingMode;
 
   ScanMatcherHandler(BotParam * param);
-  RBISUpdateInterface * processMessage(const bot_core::pose_t * msg);
+  RBISUpdateInterface * processMessage(const bot_core::pose_t * msg, RBIS state, RBIM cov);
 
   ScanMatchingMode mode;
   Eigen::VectorXi z_indices;
@@ -144,7 +145,7 @@ public:
 class OpticalFlowHandler {
 public:
   OpticalFlowHandler(BotParam * param, BotFrames * frames);
-  RBISUpdateInterface * processMessage(const pronto::optical_flow_t * msg);
+  RBISUpdateInterface * processMessage(const pronto::optical_flow_t * msg, RBIS state, RBIM cov);
 
   BotTrans body_to_cam;
   Eigen::Vector3d body_to_cam_trans; // In body frame, not camera frame


### PR DESCRIPTION
- removes requirements for BDI orientation estimate in with Val and Atlas
- provides state vector to measurement classes
- state (esp orientation) now used in kinematic estimator module 

Adds a mod to ignore initial velocity and assume zero for the first ~200 frames. this isn't wonderful but decouples the orientation from the lin velocity.

Worked just fine for an Atlas log:
https://www.dropbox.com/s/fhqi00n67m26rho/atlas_200_tics.mp4?dl=0
