### PR TITLE
Add bias estimation modes

### DIFF
--- a/motion_estimate/src/foot_contact/FootContact.cpp
+++ b/motion_estimate/src/foot_contact/FootContact.cpp
@@ -3,8 +3,8 @@
 using namespace TwoLegs;
 using namespace std;
 
-FootContact::FootContact(bool log_data_files_, float atlas_weight_, float schmitt_level_):
-     atlas_weight_(atlas_weight_), schmitt_level_(schmitt_level_){
+FootContact::FootContact(bool log_data_files_, float total_force_, float schmitt_level_):
+     total_force_(total_force_), schmitt_level_(schmitt_level_){
   cout << "A new FootContact object was created" << endl;
 
   // was 1400*0.65 for a long time, but this didn't work with toe-off
@@ -34,7 +34,7 @@ footid FootContact::DetectFootTransition(int64_t utime, float leftz, float right
 
   footid new_footstep = FOOT_UNKNOWN;
 
-  if (getSecondaryFootZforce() - schmitt_level_*atlas_weight_ > getPrimaryFootZforce()) {
+  if (getSecondaryFootZforce() - schmitt_level_*total_force_ > getPrimaryFootZforce()) {
     transition_timespan += deltautime;
   }else{
     transition_timespan = 0.;

--- a/motion_estimate/src/foot_contact/FootContact.h
+++ b/motion_estimate/src/foot_contact/FootContact.h
@@ -22,7 +22,7 @@ class FootContact {
 
     /////////////////////////////////////////////////
     footid standing_foot;
-    float atlas_weight_;
+    float total_force_;
     int64_t transition_timespan;
     bool foottransitionintermediateflag;
 
@@ -37,7 +37,7 @@ class FootContact {
 
 
   public:     
-    FootContact (bool log_data_files_, float atlas_weight_, float schmitt_level_);
+    FootContact (bool log_data_files_, float total_force_, float schmitt_level_);
 
     void terminate();
 

--- a/motion_estimate/src/fusion/fusion.cpp
+++ b/motion_estimate/src/fusion/fusion.cpp
@@ -158,17 +158,12 @@ public:
       ins_handler = new InsHandler(front_end->param, front_end->frames);
 
       // TODO: enable easy switching between inertial sensors:
-      if( ins_handler->channel =="MICROSTRAIN_INS"){
+      if( ins_handler->channel =="ATLAS_IMU_BATCH"){
+        front_end->addSensor("ins", &MavStateEst::InsHandler::processMessageAtlas, ins_handler);
+        rbis_initializer->addSensor("ins", &MavStateEst::InsHandler::processMessageInitAtlas, ins_handler);
+      }else{
         front_end->addSensor("ins", &MavStateEst::InsHandler::processMessage, ins_handler);
         rbis_initializer->addSensor("ins", &MavStateEst::InsHandler::processMessageInit, ins_handler);
-      }else if( ins_handler->channel =="ATLAS_IMU_BATCH"){
-        front_end->addSensor("ins", &MavStateEst::InsHandler::processMessageAtlas, ins_handler);
-        rbis_initializer->addSensor("ins", &MavStateEst::InsHandler::processMessageInitAtlas, ins_handler);
-      }else if( ins_handler->channel =="ATLAS_IMU_BATCH_FILTERED"){
-        std::cout << "Filtered IMU expected\n";
-        // messages will not be incorporated twice, either this or the other - but not both
-        front_end->addSensor("ins", &MavStateEst::InsHandler::processMessageAtlas, ins_handler);
-        rbis_initializer->addSensor("ins", &MavStateEst::InsHandler::processMessageInitAtlas, ins_handler);
       }
     }
 

--- a/motion_estimate/src/leg_estimate/leg_estimate.cpp
+++ b/motion_estimate/src/leg_estimate/leg_estimate.cpp
@@ -93,11 +93,11 @@ leg_estimate::leg_estimate( boost::shared_ptr<lcm::LCM> &lcm_publish_,
   pc_vis_->obj_cfg_list.push_back( obj_cfg(1023,"Secondary Foot [const] ",5,1) );
 
   // actually more like 1540N when standing still in Jan 2014, but don't change
-  float atlas_weight = bot_param_get_double_or_fail(botparam_, "state_estimator.legodo.atlas_weight");
+  float total_force = bot_param_get_double_or_fail(botparam_, "state_estimator.legodo.total_force");
 
   float standing_schmitt_level = bot_param_get_double_or_fail(botparam_, "state_estimator.legodo.standing_schmitt_level");
   // originally foot shift was when s_foot - 1400*0.65  > p_foot   ... typically s_foot = 1180 | p_foot =200 (~75%)
-  foot_contact_logic_ = new TwoLegs::FootContact(false, atlas_weight, standing_schmitt_level);
+  foot_contact_logic_ = new TwoLegs::FootContact(false, total_force, standing_schmitt_level);
   foot_contact_logic_->setStandingFoot( FOOT_LEFT );
 
   float schmitt_low_threshold = bot_param_get_double_or_fail(botparam_, "state_estimator.legodo.schmitt_low_threshold");

--- a/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
+++ b/motion_estimate/src/mav_est_legodo/rbis_legodo_update.hpp
@@ -63,6 +63,7 @@ public:
   boost::shared_ptr<lcm::LCM> lcm_pub_boost;
   boost::shared_ptr<ModelClient> model_boost;
   BotFrames* frames;
+  std::string channel_force_torque;
   
   // Settings 
   // Number of iterations to assume are zero velocity at start:
@@ -71,6 +72,8 @@ public:
   bool republish_incoming_poses_;
   // Publish Debug Data e.g. kinematic velocities and foot contacts
   bool publish_diagnostics_;
+  // Republish core sensors - currently just Force/Torque
+  bool republish_sensors_;
   int verbose_; 
   
   // Torque Adjustment:

--- a/state-estimator/src/mav_state_est/sensor_handlers.cpp
+++ b/state-estimator/src/mav_state_est/sensor_handlers.cpp
@@ -4,10 +4,15 @@ using namespace Eigen;
 
 namespace MavStateEst {
 
-InsHandler::InsHandler(BotParam * _param, BotFrames * _frames)
-{
-  // mfallon: this chooses between MICROSTRAIN and ATLAS_IMU_BATCH
-  channel = bot_param_get_str_or_fail(_param, "state_estimator.ins.channel");
+InsHandler::InsHandler(BotParam * _param, BotFrames * _frames) :
+    accel_bias_update(true),
+    gyro_bias_update(true),
+    accel_bias_initial(Eigen::Vector3d::Zero()),
+    gyro_bias_initial(Eigen::Vector3d::Zero()),
+    online_accel_bias_initial(true),
+    online_gyro_bias_initial(true){
+    // mfallon: this chooses between MICROSTRAIN and ATLAS_IMU_BATCH
+    channel = bot_param_get_str_or_fail(_param, "state_estimator.ins.channel");
 
   cov_gyro = bot_param_get_double_or_fail(_param, "state_estimator.ins.q_gyro");
   cov_gyro = bot_sq(bot_to_radians(cov_gyro));
@@ -46,6 +51,48 @@ InsHandler::InsHandler(BotParam * _param, BotFrames * _frames)
   g_vec_sum.setZero();
   mag_vec_sum.setZero();
   gyro_bias_sum.setZero();
+
+  int tmp_int = bot_param_get_boolean_or_fail(_param, "state_estimator.ins.accel_bias_update");
+  accel_bias_update = (tmp_int == 0 ? false : true);
+
+  double accel_bias_initial_array[3];
+  bot_param_get_double_array_or_fail(_param, "state_estimator.ins.accel_bias_initial", accel_bias_initial_array, 3);
+  accel_bias_initial << accel_bias_initial_array[0], accel_bias_initial_array[1], accel_bias_initial_array[2];
+  std::cout << "Setting initial accel bias to: " << accel_bias_initial.transpose() << std::endl;
+  std::cout << "INS set to ";
+  std::cout << (accel_bias_update ? "" : "NOT");
+  std::cout << "update accel bias" << std::endl;
+  // If we don't want to update the bias, the covariance must be 0
+  if(!accel_bias_update){
+      cov_accel_bias = 0.0;
+  }
+
+  tmp_int = bot_param_get_boolean_or_fail(_param, "state_estimator.ins.gyro_bias_update");
+  gyro_bias_update = (tmp_int == 0 ? false : true);
+
+  double gyro_bias_initial_array[3];
+  bot_param_get_double_array_or_fail(_param, "state_estimator.ins.gyro_bias_initial", gyro_bias_initial_array, 3);
+  gyro_bias_initial << gyro_bias_initial_array[0], gyro_bias_initial_array[1], gyro_bias_initial_array[2];
+  std::cout << "Setting initial gyro bias to: " << gyro_bias_initial.transpose() << std::endl;
+  std::cout << "INS set to ";
+  std::cout << (gyro_bias_update ? "" : "NOT ");
+  std::cout << "update gyro bias" << std::endl;
+  // If we don't want to update the bias, the covariance must be 0
+  if(!gyro_bias_update){
+      cov_gyro_bias = 0.0;
+  }
+
+  tmp_int = bot_param_get_boolean_or_fail(_param, "state_estimator.ins.online_accel_bias_initial");
+  online_accel_bias_initial = (tmp_int == 0 ? false : true);
+  std::cout << "INS set to ";
+  std::cout << (online_accel_bias_initial ? "" : "NOT ");
+  std::cout << "compute initial accel bias online at the beginning" << std::endl;
+
+  tmp_int = bot_param_get_boolean_or_fail(_param, "state_estimator.ins.online_gyro_bias_initial");
+  online_gyro_bias_initial = (tmp_int == 0 ? false : true);
+  std::cout << "INS set to ";
+  std::cout << (online_gyro_bias_initial ? "" : "NOT ");
+  std::cout << "compute initial gyro bias online at the beginning" << std::endl;
 }
 
 ////////// Typical Micro Strain INS /////////////////
@@ -63,7 +110,25 @@ RBISUpdateInterface * InsHandler::processMessage(const bot_core::ins_t * msg, RB
   bot_quat_rotate_to(ins_to_body.rot_quat, msg->gyro, body_gyro);
   Eigen::Map<Eigen::Vector3d> gyro(body_gyro);
 
-  return new RBISIMUProcessStep(gyro, accelerometer, cov_gyro, cov_accel, cov_gyro_bias, cov_accel_bias, dt, msg->utime);
+    RBISIMUProcessStep* update = new RBISIMUProcessStep(gyro,
+            accelerometer,
+            cov_gyro,
+            cov_accel,
+            cov_gyro_bias,
+            cov_accel_bias,
+            dt,
+            msg->utime);
+
+    // We reset the bias values to the original value, if requested
+    if(!gyro_bias_update) {
+        update->posterior_state.gyroBias() = gyro_bias_initial;
+    }
+
+    if(!accel_bias_update) {
+        update->posterior_state.accelBias() = accel_bias_initial;
+    }
+
+    return update;
 }
 
 bool InsHandler::processMessageInit(const bot_core::ins_t * msg,
@@ -281,6 +346,22 @@ bool InsHandler::processMessageInitCommon(const std::map<std::string, bool> & se
       Eigen::Vector3d mag_vec_rpy = bot_to_degrees(eigen_utils::getEulerAngles(quat_mag));
       fprintf(stderr, "Yaw Initialized from INS: %f\n", mag_vec_rpy(2));
     }
+
+    if(online_accel_bias_initial) {
+        std::cout << "Using online estimated accel bias: ";
+        std::cout << init_state.accelBias().transpose() << std::endl;
+        accel_bias_initial = init_state.accelBias();
+    }
+
+    if(online_gyro_bias_initial){
+        std::cout << "Using online estimated gyro bias: ";
+        std::cout << init_state.gyroBias().transpose() << std::endl;
+        gyro_bias_initial = init_state.gyroBias();
+    }
+
+    init_state.gyroBias() = gyro_bias_initial;
+    init_state.accelBias() = accel_bias_initial;
+
     return true;
   }
 }

--- a/state-estimator/src/mav_state_est/sensor_handlers.hpp
+++ b/state-estimator/src/mav_state_est/sensor_handlers.hpp
@@ -75,13 +75,13 @@ protected:
   Eigen::Vector3d gyro_bias_sum;
 
   ////////////////////////
-  bool gyro_bias_update;
+  bool gyro_bias_update_online;
   Eigen::Vector3d gyro_bias_initial;
-  bool gyro_bias_calc_at_init;
+  bool gyro_bias_recalc_at_start;
 
-  bool accel_bias_update;
+  bool accel_bias_update_online;
   Eigen::Vector3d accel_bias_initial;
-  bool accel_bias_calc_at_init;
+  bool accel_bias_recalc_at_start;
 
 };
 

--- a/state-estimator/src/mav_state_est/sensor_handlers.hpp
+++ b/state-estimator/src/mav_state_est/sensor_handlers.hpp
@@ -21,12 +21,6 @@ namespace MavStateEst {
 
 class InsHandler {
 protected:
-  bool accel_bias_update;
-  bool gyro_bias_update;
-  Eigen::Vector3d accel_bias_initial;
-  Eigen::Vector3d gyro_bias_initial;
-  bool online_accel_bias_initial;
-  bool online_gyro_bias_initial;
 
   void create(BotParam * _param, BotFrames * _frames);
   public:
@@ -79,6 +73,16 @@ protected:
   Eigen::Vector3d g_vec_sum;
   Eigen::Vector3d mag_vec_sum;
   Eigen::Vector3d gyro_bias_sum;
+
+  ////////////////////////
+  bool gyro_bias_update;
+  Eigen::Vector3d gyro_bias_initial;
+  bool gyro_bias_calc_at_init;
+
+  bool accel_bias_update;
+  Eigen::Vector3d accel_bias_initial;
+  bool accel_bias_calc_at_init;
+
 };
 
 

--- a/state-estimator/src/mav_state_est/sensor_handlers.hpp
+++ b/state-estimator/src/mav_state_est/sensor_handlers.hpp
@@ -21,6 +21,13 @@ namespace MavStateEst {
 
 class InsHandler {
 protected:
+  bool accel_bias_update;
+  bool gyro_bias_update;
+  Eigen::Vector3d accel_bias_initial;
+  Eigen::Vector3d gyro_bias_initial;
+  bool online_accel_bias_initial;
+  bool online_gyro_bias_initial;
+
   void create(BotParam * _param, BotFrames * _frames);
   public:
   InsHandler(BotParam * _param, BotFrames * _frames);


### PR DESCRIPTION
Re-opening: https://github.com/openhumanoids/pronto/pull/53
Which also is related to https://github.com/openhumanoids/pronto/pull/49

requires this block in the cfg:

    accel_bias_initial = [0,0,0]; // initial user provided bias estimate
    accel_bias_calc_at_init = false; // throw out the above and re estimate when launching the robot
    accel_bias_update = false; // update this estimate during the experiment

    gyro_bias_initial = [0,0,0];
    gyro_bias_calc_at_init = false;
    gyro_bias_update = false;


does this make more logic sense @mcamurri ? Its intended to be sequential