### PR TITLE
Removed useless dependency on microstrain lcmtypes

### DIFF
--- a/state-estimator/src/CMakeLists.txt
+++ b/state-estimator/src/CMakeLists.txt
@@ -16,7 +16,6 @@ pods_use_pkg_config_packages(fixie-vicon-simple-state-estimator
 	bot2-param-client
 	bot2-frames
 	eigen-utils
-	lcmtypes_microstrain
     path-util
     lcmtypes_vicon
     lcmtypes_pronto

--- a/state-estimator/src/gpf/CMakeLists.txt
+++ b/state-estimator/src/gpf/CMakeLists.txt
@@ -20,7 +20,6 @@ set(REQUIRED_LIBS mav-state-est
 	laser-util
 	laser-sim3d
 	octomap-util
-	lcmtypes_microstrain
     path-util
     lcmtypes_vicon
     lcmtypes_pronto

--- a/state-estimator/src/testers/CMakeLists.txt
+++ b/state-estimator/src/testers/CMakeLists.txt
@@ -4,7 +4,6 @@ pods_use_pkg_config_packages(test_laser_project_with_motion
 	bot2-param-client
 	bot2-frames
 	eigen-utils
-	lcmtypes_microstrain
     path-util
     laser-util
     lcmtypes_vicon


### PR DESCRIPTION
Module `state-estimator` is completely bot-core lcmtypes migrated, but yet some old dependencies on microstrain remained.

Tested on our private copy of pronto-distro, but `grep -r ins_t | grep microstrain` executed on `$PRONTO_ROOT/pronto/state-estimator` returns only the following:
```
./src/vicon_simple_state_estimator.cpp:  bot_frames_get_trans(self->frames, "microstrain", "body", &self->ins_to_body);
```
I think it is harmless.