### PR TITLE
improve the torque adjustment interface to support valkyrie

### DIFF
--- a/estimate_tools/src/backlash_filter_tools/torque_adjustment.cpp
+++ b/estimate_tools/src/backlash_filter_tools/torque_adjustment.cpp
@@ -1,22 +1,23 @@
-// This class implements a torque adjustment suggested
-// by IHMC
+// This class implements a torque adjustment suggested by IHMC
 
 #include <estimate_tools/torque_adjustment.hpp>
 #include <cmath>
+#include <algorithm>    // std::find
+
 
 namespace EstimateTools {
 
-TorqueAdjustment::TorqueAdjustment(std::vector<float> k_):k_(k_){
+TorqueAdjustment::TorqueAdjustment(std::vector<std::string> jointsToFilter_, std::vector<float> filterGains_):
+    jointsToFilter_(jointsToFilter_),filterGains_(filterGains_){
   // Construct a torque adjustment tool with the given spring constants. The
-  // vector k_ should be the same length as the number of efforts and
+  // vector filterGains_ should be the same length as the number of efforts and
   // positions (and in the same order), and is measured in units of radians
   // per Newton-meter. To prevent torque adjustment on a joint, set its
-  // associated value of k_ to inf (since a joint with no deflection can be
+  // associated value of filterGains_ to inf (since a joint with no deflection can be
   // thought of as an infinitely stiff spring).
   std::cout << "TorqueAdjustment gains: ";
-
-  for( size_t i=0; i<k_.size(); i++)
-    std::cout << k_[i] << ' ';
+  for( size_t i=0; i<filterGains_.size(); i++)
+    std::cout << jointsToFilter_[i] << " " << filterGains_[i] << ", ";
   std::cout << "\n";
 
   max_adjustment_ = 0.1; // 0.1 was always used
@@ -32,11 +33,26 @@ float TorqueAdjustment::magnitudeLimit(float val_in){
   return val_in;
 }
 
-void TorqueAdjustment::processSample(std::vector<float> &position, std::vector<float> &effort ){
-  for (size_t i=0; i< k_.size(); i++){
-    if (std::isnormal(k_[i])) {
-      // Don't do the correction if k_[i] is zero, NaN, or infinite. 
-      position[i] -= magnitudeLimit( effort[i] / k_[i]);
+void TorqueAdjustment::processSample(std::vector<std::string> names, std::vector<float> &positions, std::vector<float> &efforts){
+
+  // Loop through list of joints to be filtered:
+  for (size_t i=0; i< jointsToFilter_.size(); i++){
+
+    // Find the joint to be filtered
+    std::string this_joint = jointsToFilter_[i];
+    int pos = std::find(names.begin(), names.end(), this_joint) - names.begin();
+
+    if(pos >= names.size()) {
+      std::cout << "TorqueAdjustment: " << this_joint << " joint not found\n";
+      exit(-1);
+    }else{
+
+      // std::cout << "adjust " << names[pos] << " " << pos << " " << "using " << jointsToFilter[i] << " " << i << "\n";
+      // Apply correction. don't do the correction if filterGains_[i] is zero, NaN, or infinite.
+      if (std::isnormal(filterGains_[i])) {
+        positions[pos] -= magnitudeLimit( efforts[pos] / filterGains_[i]);
+      }
+
     }
   }
 

--- a/estimate_tools/src/backlash_filter_tools/torque_adjustment.hpp
+++ b/estimate_tools/src/backlash_filter_tools/torque_adjustment.hpp
@@ -4,26 +4,25 @@
 #include <iostream>
 #include <inttypes.h>
 #include <vector>
-//#include "atlas/AtlasControlTypes.h"
-//#include "atlas/AtlasJointNames.h"
 
 namespace EstimateTools {
 
 class TorqueAdjustment{
   public:
-    TorqueAdjustment(std::vector<float> k_);
+    TorqueAdjustment(std::vector<std::string> jointsToFilter_, std::vector<float> filterGains_);
 
     ~TorqueAdjustment(){
     }
 
-    void processSample(std::vector<float> &position, std::vector<float> &effort );
+    void processSample(std::vector<std::string> names, std::vector<float> &positions, std::vector<float> &efforts);
 
   private:
 
     float magnitudeLimit(float val_in);
     float max_adjustment_;
 
-    std::vector<float> k_;
+    std::vector<float> filterGains_;
+    std::vector<std::string> jointsToFilter_;
 
 };
 


### PR DESCRIPTION
now checks a list of joint names explicitly.

This is what the config was previously - assuming the joint ordering:
```
   adjustment_gain = [inf, # back_bkz
                      8000, # back_bky
                      8000, # back_bkx
                      inf, # neck_ay
                      7000, # l_leg_hpz
                      8000, # l_leg_hpx
                      10000, # l_leg_hpy
                      10000, # l_leg_kny
                      10000, # l_leg_aky
                      10000, # l_leg_akx
                      7000, # r_leg_hpz
                      8000, # r_leg_hpx
                      10000, # r_leg_hpy
                      10000, # r_leg_kny
                      10000, # r_leg_aky
                      10000, # r_leg_akx
                      inf, # l_arm_shz
                      inf, # l_arm_shx
                      inf, # l_arm_ely
                      inf, # l_arm_elx
                      inf, # l_arm_uwy
                      inf, # l_arm_mwx
                      inf, # l_arm_lwy
                      inf, # r_arm_shz
                      inf, # r_arm_shx
                      inf, # r_arm_ely
                      inf, # r_arm_elx
                      inf, # r_arm_uwy
                      inf, # r_arm_mwx
                      inf]; # r_arm_lwy
```

This is what the config is now - checks the joint ordering:
```
   adjustment_gain = [8000,   8000, 
                      7000,   8000, 10000, 
                      10000, 10000, 10000,
                      7000,   8000, 10000, 
                      10000, 10000, 10000];
   
   adjustment_joints = [back_bky, back_bkx,
                        l_leg_hpz, l_leg_hpx, l_leg_hpy,
                        l_leg_kny, l_leg_aky, l_leg_akx,
                        r_leg_hpz, r_leg_hpx, r_leg_hpy,
                        r_leg_kny, r_leg_aky, r_leg_akx];
```
