### PR TITLE
remove references to "POSE_BDI"

### DIFF
--- a/motion_estimate/scripts/footstep_spoof.py
+++ b/motion_estimate/scripts/footstep_spoof.py
@@ -53,7 +53,7 @@ def on_pose_body(channel, data):
     
 def on_deprecated_footstep_plan(channel, data):
   if ( (state.got_pose_bdi == False) or (state.got_pose_body == False) ):
-    print "havent got POSE_BDI and POSE_BODY yet"
+    print "havent got POSE_BODY_ALT and POSE_BODY yet"
     return
     
   m = deprecated_footstep_plan_t.decode(data)
@@ -79,7 +79,7 @@ print "started"
 
 state = State()
 
-sub1 = lc.subscribe("POSE_BDI", on_pose_bdi)
+sub1 = lc.subscribe("POSE_BODY_ALT", on_pose_bdi)
 sub2 = lc.subscribe("POSE_BODY", on_pose_body)
 sub3 = lc.subscribe("CANDIDATE_BDI_FOOTSTEP_PLAN_MIT_FRAME", on_deprecated_footstep_plan)
 

--- a/motion_estimate/scripts/printMessageTimes.py
+++ b/motion_estimate/scripts/printMessageTimes.py
@@ -52,7 +52,7 @@ def on_atlas_state(channel, data):
 lc = lcm.LCM()
 print "started"
 
-lc.subscribe("POSE_BDI", on_pose)
+lc.subscribe("POSE_BODY_ALT", on_pose)
 lc.subscribe("ATLAS_IMU_BATCH", on_imu)
 lc.subscribe("ATLAS_STATE", on_atlas_state)
   

--- a/motion_estimate/scripts/se-batch-process.sh
+++ b/motion_estimate/scripts/se-batch-process.sh
@@ -53,10 +53,10 @@ process_log(){
   fi
 
   #se-leg-odometry -U model_LH_RH.urdf -P drc_robot_02.cfg -L $log_in -pr 0 -r -l $log_out_legodo
-  #bot-log2mat  $log_out_legodo  -c "POSE_BDI|POSE_VICON|POSE_BODY_ALT" -o $log_out_legodo_mat
+  #bot-log2mat  $log_out_legodo  -c "POSE_VICON|POSE_BODY_ALT" -o $log_out_legodo_mat
 
   se-fusion       -U model_LN_RN.urdf -P drc_robot_02_mit.cfg -L $log_in -pr 0    -l $log_out_fusion
-  bot-log2mat  $log_out_fusion  -c "POSE_BDI|POSE_VICON|POSE_BODY_ALT|POSE_BODY|POSE_MIT" -o $log_out_fusion_mat
+  bot-log2mat  $log_out_fusion  -c "POSE_VICON|POSE_BODY_ALT|POSE_BODY|POSE_MIT" -o $log_out_fusion_mat
 
   echo $log_out_legodo_mat
   echo $log_out_fusion_mat

--- a/motion_estimate/scripts/se_analysis.m
+++ b/motion_estimate/scripts/se_analysis.m
@@ -158,8 +158,8 @@ function [a,s] = do_pre_process(settings)
 a=[], b=[]
 load([settings.folder_path settings.log_filename]);
 raw = [ 0*ones(size(POSE_VICON,1),1) , POSE_VICON ];
-raw = [raw; 1*ones(size(POSE_BDI,1),1) , POSE_BDI];
-raw = [raw; 2*ones(size(POSE_BODY,1),1) , POSE_BODY]; % usedto used POSE_BODY_ALT
+raw = [raw; 1*ones(size(POSE_BODY_ALT,1),1) , POSE_BODY_ALT];
+raw = [raw; 2*ones(size(POSE_BODY,1),1) , POSE_BODY];
 res = sortrows(raw, 2);
 % convert to mins from zero
 res(:,2) = (res(:,2) - res(1,2))*1E-6;

--- a/motion_estimate/src/fusion/fusion.cpp
+++ b/motion_estimate/src/fusion/fusion.cpp
@@ -32,7 +32,7 @@ class StandingPrep{
 public:
     StandingPrep(boost::shared_ptr<lcm::LCM> &lcm_):lcm_(lcm_){
       lcm_->subscribe( "STATE_EST_READY" ,&StandingPrep::navReadyHandler,this);
-      lcm_->subscribe( "POSE_BDI" ,&StandingPrep::poseBDIHandler,this);
+      lcm_->subscribe( "POSE_BODY_ALT" ,&StandingPrep::poseBDIHandler,this);
       ready_ =false;
     }
     ~StandingPrep(){}

--- a/motion_estimate/src/leg_estimate/convert_bdi_into_vicon_frame.cpp
+++ b/motion_estimate/src/leg_estimate/convert_bdi_into_vicon_frame.cpp
@@ -216,7 +216,7 @@ App::App(boost::shared_ptr<lcm::LCM> &lcm_, const CommandLineConfig& cl_cfg_):
 
   lcm_->subscribe( "POSE_BODY" ,&App::poseESTHandler,this);
   lcm_->subscribe( "POSE_MIT" ,&App::poseMITHandler,this);
-  lcm_->subscribe( "POSE_BDI" ,&App::poseBDIHandler,this);
+  lcm_->subscribe( "POSE_BODY_ALT" ,&App::poseBDIHandler,this);
 
   if (cl_cfg_.use_pose_vicon){
     lcm_->subscribe("POSE_VICON",&App::viconPoseHandler,this);  

--- a/motion_estimate/src/leg_estimate/init_from_bdi.cpp
+++ b/motion_estimate/src/leg_estimate/init_from_bdi.cpp
@@ -1,6 +1,6 @@
 // A basic tool to initialize the state estimator
 // by pretending to be a vicon measurement
-// TODO: depreciate this and use POSE_BDI directly within mav-est
+// TODO: depreciate this and use POSE_BODY_ALT directly within mav-est
 #include <boost/shared_ptr.hpp>
 #include <lcm/lcm-cpp.hpp>
 #include <lcmtypes/bot_core.hpp>
@@ -44,7 +44,7 @@ App::App(boost::shared_ptr<lcm::LCM> &lcm_, const CommandLineConfig& cl_cfg_):
   botparam_ = bot_param_new_from_file(param_file_full.c_str());
   frames_ = bot_frames_get_global(lcm_->getUnderlyingLCM(), botparam_);
   
-  lcm_->subscribe("POSE_BDI",&App::poseBDIHandler,this);  
+  lcm_->subscribe("POSE_BODY_ALT",&App::poseBDIHandler,this);  
 }
 
 


### PR DESCRIPTION
This was used to refer to the floating base estimate from BDI which isn't used in the actual estimator anyway

Instead POSE_BODY_ALT will mean "another 3rd party estimate" of POSE_BODY