### PR TITLE
Alpha filter for low-pass joint position filtering

### DIFF
--- a/estimate_tools/src/filter_tools/AlphaFilter.cpp
+++ b/estimate_tools/src/filter_tools/AlphaFilter.cpp
@@ -30,10 +30,16 @@ void AlphaFilter::setup(const std::vector<std::string> &name, const std::vector<
     _configured = true;
 }
 
-void AlphaFilter::update(std::vector<float> &measurement) {
-    const float n_alpha = 1-_alpha;
-    for(size_t i = 0; i<_values.size(); i++) {
-        _values[i] = _alpha * measurement[_target_index[i]] +  n_alpha * _values[i];
-        measurement[_target_index[i]] = _values[i];
+void AlphaFilter::update(const std::vector<std::string> &name, std::vector<float> &measurement) {
+    if(!isConfigured()) {
+        // configure filter once
+        setup(name, measurement);
+    }
+    else {
+        const float n_alpha = 1-_alpha;
+        for(size_t i = 0; i<_values.size(); i++) {
+            _values[i] = _alpha * measurement[_target_index[i]] +  n_alpha * _values[i];
+            measurement[_target_index[i]] = _values[i];
+        }
     }
 }

--- a/estimate_tools/src/filter_tools/AlphaFilter.cpp
+++ b/estimate_tools/src/filter_tools/AlphaFilter.cpp
@@ -1,13 +1,13 @@
 #include "AlphaFilter.hpp"
 
-AlphaFilter::AlphaFilter(const std::set<std::string> &target_joints, float alpha)
-    : _configured(false), _alpha(alpha), _n_alpha(1-alpha), _target_joints(target_joints)
+AlphaFilter::AlphaFilter(const std::set<std::string> &target_joints, const float alpha)
+    : _configured(false), _alpha(alpha), _target_joints(target_joints)
 {
-    if( !(0.0<alpha && alpha<=1.0)) {
+    if( !(0.0<_alpha && _alpha<=1.0)) {
         std::cerr<<"Alpha is out of range! Truncating to [0,1]."<<std::endl;
         // truncate alpha value to valid range
-        alpha = (alpha < 0.0) ? 0.0 : alpha;
-        alpha = (alpha > 1.0) ? 1.0 : alpha;
+        _alpha = (_alpha < 0.0) ? 0.0 : _alpha;
+        _alpha = (_alpha > 1.0) ? 1.0 : _alpha;
     }
 }
 
@@ -17,7 +17,7 @@ void AlphaFilter::setup(const std::vector<std::string> &name, const std::vector<
     _values.clear();
 
     // find target joints by name and store index unless all target joints are processed
-    for(unsigned int i = 0; i<name.size() && _target_index.size() != _target_joints.size(); i++) {
+    for(size_t i = 0; i<name.size() && _target_index.size() != _target_joints.size(); i++) {
         if(_target_joints.count(name[i])) {
             _target_index.push_back(i);
             _values.push_back(values[i]);
@@ -31,8 +31,9 @@ void AlphaFilter::setup(const std::vector<std::string> &name, const std::vector<
 }
 
 void AlphaFilter::update(std::vector<float> &measurement) {
-    for(unsigned int i = 0; i<_values.size(); i++) {
-        _values[i] = _alpha * measurement[_target_index[i]] +  _n_alpha * _values[i];
+    const float n_alpha = 1-_alpha;
+    for(size_t i = 0; i<_values.size(); i++) {
+        _values[i] = _alpha * measurement[_target_index[i]] +  n_alpha * _values[i];
         measurement[_target_index[i]] = _values[i];
     }
 }

--- a/estimate_tools/src/filter_tools/AlphaFilter.cpp
+++ b/estimate_tools/src/filter_tools/AlphaFilter.cpp
@@ -1,0 +1,38 @@
+#include "AlphaFilter.hpp"
+
+AlphaFilter::AlphaFilter(const std::set<std::string> &target_joints, float alpha)
+    : _configured(false), _alpha(alpha), _n_alpha(1-alpha), _target_joints(target_joints)
+{
+    if( !(0.0<alpha && alpha<=1.0)) {
+        std::cerr<<"Alpha is out of range! Truncating to [0,1]."<<std::endl;
+        // truncate alpha value to valid range
+        alpha = (alpha < 0.0) ? 0.0 : alpha;
+        alpha = (alpha > 1.0) ? 1.0 : alpha;
+    }
+}
+
+void AlphaFilter::setup(const std::vector<std::string> &name, const std::vector<float> &values) {
+    // reset
+    _target_index.clear();
+    _values.clear();
+
+    // find target joints by name and store index unless all target joints are processed
+    for(unsigned int i = 0; i<name.size() && _target_index.size() != _target_joints.size(); i++) {
+        if(_target_joints.count(name[i])) {
+            _target_index.push_back(i);
+            _values.push_back(values[i]);
+        }
+    }
+
+    assert(_target_index.size() == _target_joints.size());
+    assert(_values.size() == _target_joints.size());
+
+    _configured = true;
+}
+
+void AlphaFilter::update(std::vector<float> &measurement) {
+    for(unsigned int i = 0; i<_values.size(); i++) {
+        _values[i] = _alpha * measurement[_target_index[i]] +  _n_alpha * _values[i];
+        measurement[_target_index[i]] = _values[i];
+    }
+}

--- a/estimate_tools/src/filter_tools/AlphaFilter.hpp
+++ b/estimate_tools/src/filter_tools/AlphaFilter.hpp
@@ -17,6 +17,21 @@ public:
     AlphaFilter(const std::set<std::string> &target_joints, float alpha);
 
     /**
+     * @brief getAlpha get alpha value
+     * @return alpha value
+     */
+    double getAlpha() { return _alpha; }
+
+    /**
+     * @brief update update the internal state of the filter by new measurements
+     * The method will exchange the provided values with the filtered values in-place.
+     * @param name full list of joint names as provided from the LCM message
+     * @param measurement new measured joint positions
+     */
+    void update(const std::vector<std::string> &name, std::vector<float> &measurement);
+
+private:
+    /**
      * @brief setup set-up the filter by obtaining the target indices and initial values
      * Call this method once (e.g. check if isConfigured returns false) to obtain the
      * indices of the target joints in the full joint vector and to set the initial
@@ -33,20 +48,6 @@ public:
      */
     bool isConfigured() { return _configured; }
 
-    /**
-     * @brief getAlpha get alpha value
-     * @return alpha value
-     */
-    double getAlpha() { return _alpha; }
-
-    /**
-     * @brief update update the internal state of the filter by new measurements
-     * The method will exchange the provided values with the filtered values in-place.
-     * @param measurement new measured joint positions
-     */
-    void update(std::vector<float> &measurement);
-
-private:
     bool _configured;       //!< flag to indicated if setup has been called
     double _alpha;          //!< alpha value of filter
     const std::set<std::string> _target_joints; //!< list of joints to be filtered

--- a/estimate_tools/src/filter_tools/AlphaFilter.hpp
+++ b/estimate_tools/src/filter_tools/AlphaFilter.hpp
@@ -48,8 +48,7 @@ public:
 
 private:
     bool _configured;       //!< flag to indicated if setup has been called
-    const double _alpha;    //!< alpha value of filter
-    const double _n_alpha;  //!< (1-alpha) value
+    double _alpha;          //!< alpha value of filter
     const std::set<std::string> _target_joints; //!< list of joints to be filtered
     std::vector<unsigned int> _target_index;    //!< indices of filtered joints in full joints
     std::vector<float> _values; //!< internal state of filter, e.g. the filtered values

--- a/estimate_tools/src/filter_tools/AlphaFilter.hpp
+++ b/estimate_tools/src/filter_tools/AlphaFilter.hpp
@@ -1,0 +1,58 @@
+#ifndef ALPHAFILTER_HPP
+#define ALPHAFILTER_HPP
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <set>
+#include <vector>
+
+class AlphaFilter {
+public:
+    /**
+     * @brief AlphaFilter alpha filter for joint position values
+     * @param target_joints list of joint names that should be filtered
+     * @param alpha the alpha value for the filter in the range 0..1
+     */
+    AlphaFilter(const std::set<std::string> &target_joints, float alpha);
+
+    /**
+     * @brief setup set-up the filter by obtaining the target indices and initial values
+     * Call this method once (e.g. check if isConfigured returns false) to obtain the
+     * indices of the target joints in the full joint vector and to set the initial
+     * filtered value x_0. After calling this method, isConfigured will return true.
+     * @param name full list of joint names as provided from the LCM message
+     * @param values full list of joint position values as provided from the LCM message
+     */
+    void setup(const std::vector<std::string> &name, const std::vector<float> &values);
+
+    /**
+     * @brief isConfigured check if setup was already called, e.g. if the target indices and initial values are known
+     * @return true if setup was called before
+     * @return false if setup has not been called before
+     */
+    bool isConfigured() { return _configured; }
+
+    /**
+     * @brief getAlpha get alpha value
+     * @return alpha value
+     */
+    double getAlpha() { return _alpha; }
+
+    /**
+     * @brief update update the internal state of the filter by new measurements
+     * The method will exchange the provided values with the filtered values in-place.
+     * @param measurement new measured joint positions
+     */
+    void update(std::vector<float> &measurement);
+
+private:
+    bool _configured;       //!< flag to indicated if setup has been called
+    const double _alpha;    //!< alpha value of filter
+    const double _n_alpha;  //!< (1-alpha) value
+    const std::set<std::string> _target_joints; //!< list of joints to be filtered
+    std::vector<unsigned int> _target_index;    //!< indices of filtered joints in full joints
+    std::vector<float> _values; //!< internal state of filter, e.g. the filtered values
+};
+
+#endif // ALPHAFILTER_HPP

--- a/estimate_tools/src/filter_tools/CMakeLists.txt
+++ b/estimate_tools/src/filter_tools/CMakeLists.txt
@@ -8,13 +8,14 @@ project(filter_tools)
 ################
 
 
-add_library(filter_tools  SHARED Filter.cpp HeavyLowPassFilter.cpp SignalTap.cpp)
+add_library(filter_tools  SHARED Filter.cpp HeavyLowPassFilter.cpp SignalTap.cpp AlphaFilter.cpp)
 pods_use_pkg_config_packages(filter_tools  ${PKG_CONFIG_DEPS}  
   eigen3)
 set_target_properties(filter_tools PROPERTIES SOVERSION 1)
 pods_install_libraries(filter_tools)
 pods_install_headers( Filter.hpp HeavyLowPassFilter.hpp
               SignalTap.hpp
+              AlphaFilter.hpp
               DESTINATION estimate_tools)
 pods_install_pkg_config_file(filter_tools
   LIBS -lfilter_tools


### PR DESCRIPTION
Low-pass filtering of given joints using an alpha filter. If the filter is not configured or `alpha = 1.0`, no filtering will take place. The values are filtered in-place, e.g. the measurements provided to update will be replaced by the filtered value.