### PR TITLE
using min and max ranges for real

### DIFF
--- a/motion_estimate/src/create_octomap/cloud_accumulate.cpp
+++ b/motion_estimate/src/create_octomap/cloud_accumulate.cpp
@@ -96,7 +96,7 @@ pronto::PointCloud*  CloudAccumulate::convertPlanarScanToCloud(std::shared_ptr<b
   scan_body->points.resize (projected_laser_scan_->npoints);
   int n_valid =0;
   for (int i = 0; i < projected_laser_scan_->npoints; i++) {
-    if (( projected_laser_scan_->rawScan->ranges[i] < 30.0) && ( projected_laser_scan_->rawScan->ranges[i] > 1.85)){
+    if (( projected_laser_scan_->rawScan->ranges[i] < ca_cfg_.max_range) && ( projected_laser_scan_->rawScan->ranges[i] > ca_cfg_.min_range)){
       scan_body->points[n_valid].x = projected_laser_scan_->points[i].x;
       scan_body->points[n_valid].y = projected_laser_scan_->points[i].y;
       scan_body->points[n_valid].z = projected_laser_scan_->points[i].z;

--- a/motion_estimate/src/create_octomap/create_octomap.cpp
+++ b/motion_estimate/src/create_octomap/create_octomap.cpp
@@ -222,6 +222,7 @@ int main(int argc, char ** argv) {
   opt.add(ca_cfg.lidar_channel, "l", "lidar_channel","lidar_channel");
   opt.add(ca_cfg.batch_size, "s", "batch_size","Size of the batch of scans");
   opt.add(ca_cfg.min_range, "m", "min_range","Min Range to use");
+  opt.add(ca_cfg.max_range, "M", "max_range","Max Range to use");
   //
   opt.add(pcd_filename, "f", "pcd_filename","Process this PCD file");    
   opt.add(input, "i", "input","Input mode: 0=lcm 1=file 2=republish pcd only");    


### PR DESCRIPTION
When creating octomap, min range can be set but it is not used, while max range can't even be set.
I've added a parameter to set max range and I forced to use min and max ranges while creating the map. 
Min range is useful when the environment is small, and max range is useful if you want to filter out outliers (e.g. points out of a window)