### PR TITLE
Upgrade pods to most recent - less warnings

### DIFF
--- a/bot2-frames_cpp/cmake/pods.cmake
+++ b/bot2-frames_cpp/cmake/pods.cmake
@@ -26,7 +26,7 @@
 #
 # ----
 # File: pods.cmake
-# Distributed with pods version: 12.01.11
+# Distributed with pods version: 12.11.14
 
 # pods_install_headers(<header1.h> ... DESTINATION <subdir_name>)
 # 
@@ -51,9 +51,9 @@ function(pods_install_headers)
     foreach(header ${ARGV})
         get_filename_component(_header_name ${header} NAME)
         configure_file(${header} ${INCLUDE_OUTPUT_PATH}/${dest_dir}/${_header_name} COPYONLY)
-	endforeach(header)
-	#mark them to be installed
-	install(FILES ${ARGV} DESTINATION include/${dest_dir})
+    endforeach(header)
+    #mark them to be installed
+    install(FILES ${ARGV} DESTINATION include/${dest_dir})
 
 
 endfunction(pods_install_headers)
@@ -88,7 +88,7 @@ endfunction(pods_install_libraries)
 function(pods_install_pkg_config_file)
     list(GET ARGV 0 pc_name)
     # TODO error check
-
+    
     set(pc_version 0.0.1)
     set(pc_description ${pc_name})
     set(pc_requires "")
@@ -191,14 +191,14 @@ function(pods_install_python_script script_name python_module_or_file)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} $*\n")    
+            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} \"$@\"\n")    
     else()
         get_filename_component(py_module ${python_module_or_file} NAME) #todo: check whether module exists?
         # write the bash script file
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} -m ${py_module} $*\n")
+            "exec ${PYTHON_EXECUTABLE} -m ${py_module} \"$@\"\n")
     endif()
     # install it...
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${script_name} DESTINATION bin)
@@ -223,12 +223,14 @@ function(_pods_install_python_package py_src_dir py_module_name)
 
     if(EXISTS "${py_src_dir}/__init__.py")
         #install the single module
-        file(GLOB_RECURSE py_files   ${py_src_dir}/*.py)
-        foreach(py_file ${py_files})
-            file(RELATIVE_PATH __tmp_path ${py_src_dir} ${py_file})
-            get_filename_component(__tmp_dir ${__tmp_path} PATH)
-            install(FILES ${py_file}
-                DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+        file(GLOB_RECURSE module_files   ${py_src_dir}/*)
+        foreach(file ${module_files})
+            if(NOT file MATCHES ".*\\.svn.*|.*\\.pyc|.*[~#]")
+                file(RELATIVE_PATH __tmp_path ${py_src_dir} ${file})
+                get_filename_component(__tmp_dir ${__tmp_path} PATH)
+                install(FILES ${file}
+                    DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+            endif()
         endforeach()
     else()
         message(FATAL_ERROR "${py_src_dir} is not a python package!\n")
@@ -299,7 +301,7 @@ macro(pods_use_pkg_config_packages target)
         OUTPUT_VARIABLE _pods_pkg_include_flags)
     string(STRIP ${_pods_pkg_include_flags} _pods_pkg_include_flags)
     string(REPLACE "-I" "" _pods_pkg_include_flags "${_pods_pkg_include_flags}")
-	separate_arguments(_pods_pkg_include_flags)
+    separate_arguments(_pods_pkg_include_flags)
     #    message("include: ${_pods_pkg_include_flags}")
     execute_process(COMMAND 
         ${PKG_CONFIG_EXECUTABLE} --libs ${ARGN}
@@ -312,12 +314,11 @@ macro(pods_use_pkg_config_packages target)
     # make the target depend on libraries that are cmake targets
     if (_pods_pkg_ldflags)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})
-        foreach(lib ${_split_ldflags})
-                string(REGEX REPLACE "^-l" "" libname ${lib})
-                get_target_property(IS_TARGET ${libname} LOCATION)
-                if (NOT IS_TARGET STREQUAL "IS_TARGET-NOTFOUND")
+        foreach(__ldflag ${_split_ldflags})
+                string(REGEX REPLACE "^-l" "" __depend_target_name ${__ldflag})
+                if(TARGET "${__depend_target_name}")
                     #message("---- ${target} depends on  ${libname}")
-                    add_dependencies(${target} ${libname})
+                    add_dependencies(${target} ${__depend_target_name})
                 endif() 
         endforeach()
     endif()
@@ -335,17 +336,17 @@ endmacro()
 # manually.
 macro(pods_config_search_paths)
     if(NOT DEFINED __pods_setup)
-		#set where files should be output locally
-	    set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-	    set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
-	    set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
-	    set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
-		
-		#set where files should be installed to
-	    set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
-	    set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
-	    set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
-	    set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+        #set where files should be output locally
+        set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
+        set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+        set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
+        set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
+        
+        #set where files should be installed to
+        set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
+        set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
+        set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
+        set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 
 
         # add build/lib/pkgconfig to the pkg-config search path
@@ -374,7 +375,9 @@ macro(pods_config_search_paths)
         
         # hack to force cmake always create install and clean targets 
         install(FILES DESTINATION)
-        add_custom_target(tmp)
+        string(RANDOM LENGTH 32 __rand_target__name__)
+        add_custom_target(${__rand_target__name__})
+        unset(__rand_target__name__)
 
         set(__pods_setup true)
     endif(NOT DEFINED __pods_setup)

--- a/estimate_tools/cmake/pods.cmake
+++ b/estimate_tools/cmake/pods.cmake
@@ -26,7 +26,7 @@
 #
 # ----
 # File: pods.cmake
-# Distributed with pods version: 12.01.11
+# Distributed with pods version: 12.11.14
 
 # pods_install_headers(<header1.h> ... DESTINATION <subdir_name>)
 # 
@@ -51,9 +51,9 @@ function(pods_install_headers)
     foreach(header ${ARGV})
         get_filename_component(_header_name ${header} NAME)
         configure_file(${header} ${INCLUDE_OUTPUT_PATH}/${dest_dir}/${_header_name} COPYONLY)
-	endforeach(header)
-	#mark them to be installed
-	install(FILES ${ARGV} DESTINATION include/${dest_dir})
+    endforeach(header)
+    #mark them to be installed
+    install(FILES ${ARGV} DESTINATION include/${dest_dir})
 
 
 endfunction(pods_install_headers)
@@ -88,7 +88,7 @@ endfunction(pods_install_libraries)
 function(pods_install_pkg_config_file)
     list(GET ARGV 0 pc_name)
     # TODO error check
-
+    
     set(pc_version 0.0.1)
     set(pc_description ${pc_name})
     set(pc_requires "")
@@ -191,14 +191,14 @@ function(pods_install_python_script script_name python_module_or_file)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} $*\n")    
+            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} \"$@\"\n")    
     else()
         get_filename_component(py_module ${python_module_or_file} NAME) #todo: check whether module exists?
         # write the bash script file
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} -m ${py_module} $*\n")
+            "exec ${PYTHON_EXECUTABLE} -m ${py_module} \"$@\"\n")
     endif()
     # install it...
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${script_name} DESTINATION bin)
@@ -223,12 +223,14 @@ function(_pods_install_python_package py_src_dir py_module_name)
 
     if(EXISTS "${py_src_dir}/__init__.py")
         #install the single module
-        file(GLOB_RECURSE py_files   ${py_src_dir}/*.py)
-        foreach(py_file ${py_files})
-            file(RELATIVE_PATH __tmp_path ${py_src_dir} ${py_file})
-            get_filename_component(__tmp_dir ${__tmp_path} PATH)
-            install(FILES ${py_file}
-                DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+        file(GLOB_RECURSE module_files   ${py_src_dir}/*)
+        foreach(file ${module_files})
+            if(NOT file MATCHES ".*\\.svn.*|.*\\.pyc|.*[~#]")
+                file(RELATIVE_PATH __tmp_path ${py_src_dir} ${file})
+                get_filename_component(__tmp_dir ${__tmp_path} PATH)
+                install(FILES ${file}
+                    DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+            endif()
         endforeach()
     else()
         message(FATAL_ERROR "${py_src_dir} is not a python package!\n")
@@ -299,7 +301,7 @@ macro(pods_use_pkg_config_packages target)
         OUTPUT_VARIABLE _pods_pkg_include_flags)
     string(STRIP ${_pods_pkg_include_flags} _pods_pkg_include_flags)
     string(REPLACE "-I" "" _pods_pkg_include_flags "${_pods_pkg_include_flags}")
-	separate_arguments(_pods_pkg_include_flags)
+    separate_arguments(_pods_pkg_include_flags)
     #    message("include: ${_pods_pkg_include_flags}")
     execute_process(COMMAND 
         ${PKG_CONFIG_EXECUTABLE} --libs ${ARGN}
@@ -312,12 +314,11 @@ macro(pods_use_pkg_config_packages target)
     # make the target depend on libraries that are cmake targets
     if (_pods_pkg_ldflags)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})
-        foreach(lib ${_split_ldflags})
-                string(REGEX REPLACE "^-l" "" libname ${lib})
-                get_target_property(IS_TARGET ${libname} LOCATION)
-                if (NOT IS_TARGET STREQUAL "IS_TARGET-NOTFOUND")
+        foreach(__ldflag ${_split_ldflags})
+                string(REGEX REPLACE "^-l" "" __depend_target_name ${__ldflag})
+                if(TARGET "${__depend_target_name}")
                     #message("---- ${target} depends on  ${libname}")
-                    add_dependencies(${target} ${libname})
+                    add_dependencies(${target} ${__depend_target_name})
                 endif() 
         endforeach()
     endif()
@@ -335,17 +336,17 @@ endmacro()
 # manually.
 macro(pods_config_search_paths)
     if(NOT DEFINED __pods_setup)
-		#set where files should be output locally
-	    set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-	    set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
-	    set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
-	    set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
-		
-		#set where files should be installed to
-	    set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
-	    set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
-	    set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
-	    set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+        #set where files should be output locally
+        set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
+        set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+        set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
+        set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
+        
+        #set where files should be installed to
+        set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
+        set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
+        set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
+        set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 
 
         # add build/lib/pkgconfig to the pkg-config search path
@@ -374,7 +375,9 @@ macro(pods_config_search_paths)
         
         # hack to force cmake always create install and clean targets 
         install(FILES DESTINATION)
-        add_custom_target(tmp)
+        string(RANDOM LENGTH 32 __rand_target__name__)
+        add_custom_target(${__rand_target__name__})
+        unset(__rand_target__name__)
 
         set(__pods_setup true)
     endif(NOT DEFINED __pods_setup)

--- a/lidar_odometry/cmake/pods.cmake
+++ b/lidar_odometry/cmake/pods.cmake
@@ -26,7 +26,7 @@
 #
 # ----
 # File: pods.cmake
-# Distributed with pods version: 12.09.21
+# Distributed with pods version: 12.11.14
 
 # pods_install_headers(<header1.h> ... DESTINATION <subdir_name>)
 # 
@@ -51,9 +51,9 @@ function(pods_install_headers)
     foreach(header ${ARGV})
         get_filename_component(_header_name ${header} NAME)
         configure_file(${header} ${INCLUDE_OUTPUT_PATH}/${dest_dir}/${_header_name} COPYONLY)
-	endforeach(header)
-	#mark them to be installed
-	install(FILES ${ARGV} DESTINATION include/${dest_dir})
+    endforeach(header)
+    #mark them to be installed
+    install(FILES ${ARGV} DESTINATION include/${dest_dir})
 
 
 endfunction(pods_install_headers)
@@ -191,14 +191,14 @@ function(pods_install_python_script script_name python_module_or_file)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} $*\n")    
+            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} \"$@\"\n")    
     else()
         get_filename_component(py_module ${python_module_or_file} NAME) #todo: check whether module exists?
         # write the bash script file
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} -m ${py_module} $*\n")
+            "exec ${PYTHON_EXECUTABLE} -m ${py_module} \"$@\"\n")
     endif()
     # install it...
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${script_name} DESTINATION bin)
@@ -223,12 +223,14 @@ function(_pods_install_python_package py_src_dir py_module_name)
 
     if(EXISTS "${py_src_dir}/__init__.py")
         #install the single module
-        file(GLOB_RECURSE py_files   ${py_src_dir}/*.py)
-        foreach(py_file ${py_files})
-            file(RELATIVE_PATH __tmp_path ${py_src_dir} ${py_file})
-            get_filename_component(__tmp_dir ${__tmp_path} PATH)
-            install(FILES ${py_file}
-                DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+        file(GLOB_RECURSE module_files   ${py_src_dir}/*)
+        foreach(file ${module_files})
+            if(NOT file MATCHES ".*\\.svn.*|.*\\.pyc|.*[~#]")
+                file(RELATIVE_PATH __tmp_path ${py_src_dir} ${file})
+                get_filename_component(__tmp_dir ${__tmp_path} PATH)
+                install(FILES ${file}
+                    DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+            endif()
         endforeach()
     else()
         message(FATAL_ERROR "${py_src_dir} is not a python package!\n")
@@ -299,25 +301,23 @@ macro(pods_use_pkg_config_packages target)
         OUTPUT_VARIABLE _pods_pkg_include_flags)
     string(STRIP ${_pods_pkg_include_flags} _pods_pkg_include_flags)
     string(REPLACE "-I" "" _pods_pkg_include_flags "${_pods_pkg_include_flags}")
-	separate_arguments(_pods_pkg_include_flags)
+    separate_arguments(_pods_pkg_include_flags)
     #    message("include: ${_pods_pkg_include_flags}")
     execute_process(COMMAND 
         ${PKG_CONFIG_EXECUTABLE} --libs ${ARGN}
         OUTPUT_VARIABLE _pods_pkg_ldflags)
     string(STRIP ${_pods_pkg_ldflags} _pods_pkg_ldflags)
-    # message("ldflags: ${_pods_pkg_ldflags}")
+    #    message("ldflags: ${_pods_pkg_ldflags}")
     include_directories(${_pods_pkg_include_flags})
-    string(REPLACE " " ";" TMP ${_pods_pkg_ldflags}) #covert to a list
-    target_link_libraries(${target} ${TMP})
+    target_link_libraries(${target} ${_pods_pkg_ldflags})
     
     # make the target depend on libraries that are cmake targets
     if (_pods_pkg_ldflags)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})
         foreach(__ldflag ${_split_ldflags})
                 string(REGEX REPLACE "^-l" "" __depend_target_name ${__ldflag})
-                get_target_property(IS_TARGET ${__depend_target_name} LOCATION)
-                if (NOT IS_TARGET STREQUAL "IS_TARGET-NOTFOUND")
-                    #message("---- ${target} depends on  ${__depend_target_name}")
+                if(TARGET "${__depend_target_name}")
+                    #message("---- ${target} depends on  ${libname}")
                     add_dependencies(${target} ${__depend_target_name})
                 endif() 
         endforeach()
@@ -336,17 +336,17 @@ endmacro()
 # manually.
 macro(pods_config_search_paths)
     if(NOT DEFINED __pods_setup)
-		#set where files should be output locally
-	    set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-	    set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
-	    set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
-	    set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
-		
-		#set where files should be installed to
-	    set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
-	    set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
-	    set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
-	    set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+        #set where files should be output locally
+        set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
+        set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+        set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
+        set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
+        
+        #set where files should be installed to
+        set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
+        set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
+        set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
+        set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 
 
         # add build/lib/pkgconfig to the pkg-config search path

--- a/motion_estimate/CMakeLists.txt
+++ b/motion_estimate/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(src/foot_contact_alt)
 add_subdirectory(src/leg_estimate)
 
 # RGBD as a GPF
+# Requires kinect-lcmtypes
 ##add_subdirectory(src/gpf-rgbd-lib)
 
 # mav modules :

--- a/motion_estimate/cmake/pods.cmake
+++ b/motion_estimate/cmake/pods.cmake
@@ -26,7 +26,7 @@
 #
 # ----
 # File: pods.cmake
-# Distributed with pods version: 12.01.11
+# Distributed with pods version: 12.11.14
 
 # pods_install_headers(<header1.h> ... DESTINATION <subdir_name>)
 # 
@@ -88,7 +88,7 @@ endfunction(pods_install_libraries)
 function(pods_install_pkg_config_file)
     list(GET ARGV 0 pc_name)
     # TODO error check
-
+    
     set(pc_version 0.0.1)
     set(pc_description ${pc_name})
     set(pc_requires "")
@@ -191,14 +191,14 @@ function(pods_install_python_script script_name python_module_or_file)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} $*\n")    
+            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} \"$@\"\n")    
     else()
         get_filename_component(py_module ${python_module_or_file} NAME) #todo: check whether module exists?
         # write the bash script file
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} -m ${py_module} $*\n")
+            "exec ${PYTHON_EXECUTABLE} -m ${py_module} \"$@\"\n")
     endif()
     # install it...
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${script_name} DESTINATION bin)
@@ -223,12 +223,14 @@ function(_pods_install_python_package py_src_dir py_module_name)
 
     if(EXISTS "${py_src_dir}/__init__.py")
         #install the single module
-        file(GLOB_RECURSE py_files   ${py_src_dir}/*.py)
-        foreach(py_file ${py_files})
-            file(RELATIVE_PATH __tmp_path ${py_src_dir} ${py_file})
-            get_filename_component(__tmp_dir ${__tmp_path} PATH)
-            install(FILES ${py_file}
-                DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+        file(GLOB_RECURSE module_files   ${py_src_dir}/*)
+        foreach(file ${module_files})
+            if(NOT file MATCHES ".*\\.svn.*|.*\\.pyc|.*[~#]")
+                file(RELATIVE_PATH __tmp_path ${py_src_dir} ${file})
+                get_filename_component(__tmp_dir ${__tmp_path} PATH)
+                install(FILES ${file}
+                    DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+            endif()
         endforeach()
     else()
         message(FATAL_ERROR "${py_src_dir} is not a python package!\n")
@@ -312,12 +314,12 @@ macro(pods_use_pkg_config_packages target)
     # make the target depend on libraries that are cmake targets
     if (_pods_pkg_ldflags)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})
-        foreach(lib ${_split_ldflags})
-                string(REGEX REPLACE "^-l" "" libname ${lib})
-                get_target_property(IS_TARGET ${libname} LOCATION)
+        foreach(__ldflag ${_split_ldflags})
+                string(REGEX REPLACE "^-l" "" __depend_target_name ${__ldflag})
+                get_target_property(IS_TARGET ${__depend_target_name} LOCATION)
                 if (NOT IS_TARGET STREQUAL "IS_TARGET-NOTFOUND")
                     #message("---- ${target} depends on  ${libname}")
-                    add_dependencies(${target} ${libname})
+                    add_dependencies(${target} ${__depend_target_name})
                 endif() 
         endforeach()
     endif()
@@ -374,7 +376,9 @@ macro(pods_config_search_paths)
         
         # hack to force cmake always create install and clean targets 
         install(FILES DESTINATION)
-        add_custom_target(tmp)
+        string(RANDOM LENGTH 32 __rand_target__name__)
+        add_custom_target(${__rand_target__name__})
+        unset(__rand_target__name__)
 
         set(__pods_setup true)
     endif(NOT DEFINED __pods_setup)

--- a/pronto-lcmtypes/cmake/pods.cmake
+++ b/pronto-lcmtypes/cmake/pods.cmake
@@ -51,9 +51,9 @@ function(pods_install_headers)
     foreach(header ${ARGV})
         get_filename_component(_header_name ${header} NAME)
         configure_file(${header} ${INCLUDE_OUTPUT_PATH}/${dest_dir}/${_header_name} COPYONLY)
-	endforeach(header)
-	#mark them to be installed
-	install(FILES ${ARGV} DESTINATION include/${dest_dir})
+    endforeach(header)
+    #mark them to be installed
+    install(FILES ${ARGV} DESTINATION include/${dest_dir})
 
 
 endfunction(pods_install_headers)
@@ -301,7 +301,7 @@ macro(pods_use_pkg_config_packages target)
         OUTPUT_VARIABLE _pods_pkg_include_flags)
     string(STRIP ${_pods_pkg_include_flags} _pods_pkg_include_flags)
     string(REPLACE "-I" "" _pods_pkg_include_flags "${_pods_pkg_include_flags}")
-	separate_arguments(_pods_pkg_include_flags)
+    separate_arguments(_pods_pkg_include_flags)
     #    message("include: ${_pods_pkg_include_flags}")
     execute_process(COMMAND 
         ${PKG_CONFIG_EXECUTABLE} --libs ${ARGN}
@@ -316,8 +316,7 @@ macro(pods_use_pkg_config_packages target)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})
         foreach(__ldflag ${_split_ldflags})
                 string(REGEX REPLACE "^-l" "" __depend_target_name ${__ldflag})
-                get_target_property(IS_TARGET ${__depend_target_name} LOCATION)
-                if (NOT IS_TARGET STREQUAL "IS_TARGET-NOTFOUND")
+                if(TARGET "${__depend_target_name}")
                     #message("---- ${target} depends on  ${libname}")
                     add_dependencies(${target} ${__depend_target_name})
                 endif() 
@@ -337,17 +336,17 @@ endmacro()
 # manually.
 macro(pods_config_search_paths)
     if(NOT DEFINED __pods_setup)
-		#set where files should be output locally
-	    set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-	    set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
-	    set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
-	    set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
-		
-		#set where files should be installed to
-	    set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
-	    set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
-	    set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
-	    set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+        #set where files should be output locally
+        set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
+        set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+        set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
+        set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
+        
+        #set where files should be installed to
+        set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
+        set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
+        set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
+        set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 
 
         # add build/lib/pkgconfig to the pkg-config search path

--- a/pronto-utils/cmake/pods.cmake
+++ b/pronto-utils/cmake/pods.cmake
@@ -26,7 +26,7 @@
 #
 # ----
 # File: pods.cmake
-# Distributed with pods version: 12.09.21
+# Distributed with pods version: 12.11.14
 
 # pods_install_headers(<header1.h> ... DESTINATION <subdir_name>)
 # 
@@ -51,9 +51,9 @@ function(pods_install_headers)
     foreach(header ${ARGV})
         get_filename_component(_header_name ${header} NAME)
         configure_file(${header} ${INCLUDE_OUTPUT_PATH}/${dest_dir}/${_header_name} COPYONLY)
-	endforeach(header)
-	#mark them to be installed
-	install(FILES ${ARGV} DESTINATION include/${dest_dir})
+    endforeach(header)
+    #mark them to be installed
+    install(FILES ${ARGV} DESTINATION include/${dest_dir})
 
 
 endfunction(pods_install_headers)
@@ -191,14 +191,14 @@ function(pods_install_python_script script_name python_module_or_file)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} $*\n")    
+            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} \"$@\"\n")    
     else()
         get_filename_component(py_module ${python_module_or_file} NAME) #todo: check whether module exists?
         # write the bash script file
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} -m ${py_module} $*\n")
+            "exec ${PYTHON_EXECUTABLE} -m ${py_module} \"$@\"\n")
     endif()
     # install it...
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${script_name} DESTINATION bin)
@@ -223,12 +223,14 @@ function(_pods_install_python_package py_src_dir py_module_name)
 
     if(EXISTS "${py_src_dir}/__init__.py")
         #install the single module
-        file(GLOB_RECURSE py_files   ${py_src_dir}/*.py)
-        foreach(py_file ${py_files})
-            file(RELATIVE_PATH __tmp_path ${py_src_dir} ${py_file})
-            get_filename_component(__tmp_dir ${__tmp_path} PATH)
-            install(FILES ${py_file}
-                DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+        file(GLOB_RECURSE module_files   ${py_src_dir}/*)
+        foreach(file ${module_files})
+            if(NOT file MATCHES ".*\\.svn.*|.*\\.pyc|.*[~#]")
+                file(RELATIVE_PATH __tmp_path ${py_src_dir} ${file})
+                get_filename_component(__tmp_dir ${__tmp_path} PATH)
+                install(FILES ${file}
+                    DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+            endif()
         endforeach()
     else()
         message(FATAL_ERROR "${py_src_dir} is not a python package!\n")
@@ -299,7 +301,7 @@ macro(pods_use_pkg_config_packages target)
         OUTPUT_VARIABLE _pods_pkg_include_flags)
     string(STRIP ${_pods_pkg_include_flags} _pods_pkg_include_flags)
     string(REPLACE "-I" "" _pods_pkg_include_flags "${_pods_pkg_include_flags}")
-	separate_arguments(_pods_pkg_include_flags)
+    separate_arguments(_pods_pkg_include_flags)
     #    message("include: ${_pods_pkg_include_flags}")
     execute_process(COMMAND 
         ${PKG_CONFIG_EXECUTABLE} --libs ${ARGN}
@@ -314,8 +316,7 @@ macro(pods_use_pkg_config_packages target)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})
         foreach(__ldflag ${_split_ldflags})
                 string(REGEX REPLACE "^-l" "" __depend_target_name ${__ldflag})
-                get_target_property(IS_TARGET ${__depend_target_name} LOCATION)
-                if (NOT IS_TARGET STREQUAL "IS_TARGET-NOTFOUND")
+                if(TARGET "${__depend_target_name}")
                     #message("---- ${target} depends on  ${libname}")
                     add_dependencies(${target} ${__depend_target_name})
                 endif() 
@@ -335,17 +336,17 @@ endmacro()
 # manually.
 macro(pods_config_search_paths)
     if(NOT DEFINED __pods_setup)
-		#set where files should be output locally
-	    set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-	    set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
-	    set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
-	    set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
-		
-		#set where files should be installed to
-	    set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
-	    set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
-	    set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
-	    set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+        #set where files should be output locally
+        set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
+        set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+        set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
+        set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
+        
+        #set where files should be installed to
+        set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
+        set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
+        set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
+        set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 
 
         # add build/lib/pkgconfig to the pkg-config search path

--- a/state-estimator/cmake/pods.cmake
+++ b/state-estimator/cmake/pods.cmake
@@ -26,7 +26,7 @@
 #
 # ----
 # File: pods.cmake
-# Distributed with pods version: 12.09.21
+# Distributed with pods version: 12.11.14
 
 # pods_install_headers(<header1.h> ... DESTINATION <subdir_name>)
 # 
@@ -51,9 +51,9 @@ function(pods_install_headers)
     foreach(header ${ARGV})
         get_filename_component(_header_name ${header} NAME)
         configure_file(${header} ${INCLUDE_OUTPUT_PATH}/${dest_dir}/${_header_name} COPYONLY)
-	endforeach(header)
-	#mark them to be installed
-	install(FILES ${ARGV} DESTINATION include/${dest_dir})
+    endforeach(header)
+    #mark them to be installed
+    install(FILES ${ARGV} DESTINATION include/${dest_dir})
 
 
 endfunction(pods_install_headers)
@@ -191,14 +191,14 @@ function(pods_install_python_script script_name python_module_or_file)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} $*\n")    
+            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} \"$@\"\n")    
     else()
         get_filename_component(py_module ${python_module_or_file} NAME) #todo: check whether module exists?
         # write the bash script file
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} -m ${py_module} $*\n")
+            "exec ${PYTHON_EXECUTABLE} -m ${py_module} \"$@\"\n")
     endif()
     # install it...
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${script_name} DESTINATION bin)
@@ -223,12 +223,14 @@ function(_pods_install_python_package py_src_dir py_module_name)
 
     if(EXISTS "${py_src_dir}/__init__.py")
         #install the single module
-        file(GLOB_RECURSE py_files   ${py_src_dir}/*.py)
-        foreach(py_file ${py_files})
-            file(RELATIVE_PATH __tmp_path ${py_src_dir} ${py_file})
-            get_filename_component(__tmp_dir ${__tmp_path} PATH)
-            install(FILES ${py_file}
-                DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+        file(GLOB_RECURSE module_files   ${py_src_dir}/*)
+        foreach(file ${module_files})
+            if(NOT file MATCHES ".*\\.svn.*|.*\\.pyc|.*[~#]")
+                file(RELATIVE_PATH __tmp_path ${py_src_dir} ${file})
+                get_filename_component(__tmp_dir ${__tmp_path} PATH)
+                install(FILES ${file}
+                    DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+            endif()
         endforeach()
     else()
         message(FATAL_ERROR "${py_src_dir} is not a python package!\n")
@@ -299,7 +301,7 @@ macro(pods_use_pkg_config_packages target)
         OUTPUT_VARIABLE _pods_pkg_include_flags)
     string(STRIP ${_pods_pkg_include_flags} _pods_pkg_include_flags)
     string(REPLACE "-I" "" _pods_pkg_include_flags "${_pods_pkg_include_flags}")
-	separate_arguments(_pods_pkg_include_flags)
+    separate_arguments(_pods_pkg_include_flags)
     #    message("include: ${_pods_pkg_include_flags}")
     execute_process(COMMAND 
         ${PKG_CONFIG_EXECUTABLE} --libs ${ARGN}
@@ -314,8 +316,7 @@ macro(pods_use_pkg_config_packages target)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})
         foreach(__ldflag ${_split_ldflags})
                 string(REGEX REPLACE "^-l" "" __depend_target_name ${__ldflag})
-                get_target_property(IS_TARGET ${__depend_target_name} LOCATION)
-                if (NOT IS_TARGET STREQUAL "IS_TARGET-NOTFOUND")
+                if(TARGET "${__depend_target_name}")
                     #message("---- ${target} depends on  ${libname}")
                     add_dependencies(${target} ${__depend_target_name})
                 endif() 
@@ -335,17 +336,17 @@ endmacro()
 # manually.
 macro(pods_config_search_paths)
     if(NOT DEFINED __pods_setup)
-		#set where files should be output locally
-	    set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-	    set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
-	    set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
-	    set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
-		
-		#set where files should be installed to
-	    set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
-	    set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
-	    set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
-	    set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+        #set where files should be output locally
+        set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
+        set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+        set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
+        set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
+        
+        #set where files should be installed to
+        set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
+        set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
+        set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
+        set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 
 
         # add build/lib/pkgconfig to the pkg-config search path

--- a/visualization/cmake/pods.cmake
+++ b/visualization/cmake/pods.cmake
@@ -26,7 +26,7 @@
 #
 # ----
 # File: pods.cmake
-# Distributed with pods version: 12.09.21
+# Distributed with pods version: 12.11.14
 
 # pods_install_headers(<header1.h> ... DESTINATION <subdir_name>)
 # 
@@ -51,9 +51,9 @@ function(pods_install_headers)
     foreach(header ${ARGV})
         get_filename_component(_header_name ${header} NAME)
         configure_file(${header} ${INCLUDE_OUTPUT_PATH}/${dest_dir}/${_header_name} COPYONLY)
-	endforeach(header)
-	#mark them to be installed
-	install(FILES ${ARGV} DESTINATION include/${dest_dir})
+    endforeach(header)
+    #mark them to be installed
+    install(FILES ${ARGV} DESTINATION include/${dest_dir})
 
 
 endfunction(pods_install_headers)
@@ -191,14 +191,14 @@ function(pods_install_python_script script_name python_module_or_file)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} $*\n")    
+            "exec ${PYTHON_EXECUTABLE} ${pods_scripts_dir}/${py_script_name} \"$@\"\n")    
     else()
         get_filename_component(py_module ${python_module_or_file} NAME) #todo: check whether module exists?
         # write the bash script file
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${script_name} 
             "#!/bin/sh\n"
             "export PYTHONPATH=${python_install_dir}:${python_old_install_dir}:\${PYTHONPATH}\n"
-            "exec ${PYTHON_EXECUTABLE} -m ${py_module} $*\n")
+            "exec ${PYTHON_EXECUTABLE} -m ${py_module} \"$@\"\n")
     endif()
     # install it...
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${script_name} DESTINATION bin)
@@ -223,12 +223,14 @@ function(_pods_install_python_package py_src_dir py_module_name)
 
     if(EXISTS "${py_src_dir}/__init__.py")
         #install the single module
-        file(GLOB_RECURSE py_files   ${py_src_dir}/*.py)
-        foreach(py_file ${py_files})
-            file(RELATIVE_PATH __tmp_path ${py_src_dir} ${py_file})
-            get_filename_component(__tmp_dir ${__tmp_path} PATH)
-            install(FILES ${py_file}
-                DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+        file(GLOB_RECURSE module_files   ${py_src_dir}/*)
+        foreach(file ${module_files})
+            if(NOT file MATCHES ".*\\.svn.*|.*\\.pyc|.*[~#]")
+                file(RELATIVE_PATH __tmp_path ${py_src_dir} ${file})
+                get_filename_component(__tmp_dir ${__tmp_path} PATH)
+                install(FILES ${file}
+                    DESTINATION "${python_install_dir}/${py_module_name}/${__tmp_dir}")
+            endif()
         endforeach()
     else()
         message(FATAL_ERROR "${py_src_dir} is not a python package!\n")
@@ -299,7 +301,7 @@ macro(pods_use_pkg_config_packages target)
         OUTPUT_VARIABLE _pods_pkg_include_flags)
     string(STRIP ${_pods_pkg_include_flags} _pods_pkg_include_flags)
     string(REPLACE "-I" "" _pods_pkg_include_flags "${_pods_pkg_include_flags}")
-	separate_arguments(_pods_pkg_include_flags)
+    separate_arguments(_pods_pkg_include_flags)
     #    message("include: ${_pods_pkg_include_flags}")
     execute_process(COMMAND 
         ${PKG_CONFIG_EXECUTABLE} --libs ${ARGN}
@@ -314,8 +316,7 @@ macro(pods_use_pkg_config_packages target)
         string(REPLACE " " ";" _split_ldflags ${_pods_pkg_ldflags})
         foreach(__ldflag ${_split_ldflags})
                 string(REGEX REPLACE "^-l" "" __depend_target_name ${__ldflag})
-                get_target_property(IS_TARGET ${__depend_target_name} LOCATION)
-                if (NOT IS_TARGET STREQUAL "IS_TARGET-NOTFOUND")
+                if(TARGET "${__depend_target_name}")
                     #message("---- ${target} depends on  ${libname}")
                     add_dependencies(${target} ${__depend_target_name})
                 endif() 
@@ -335,17 +336,17 @@ endmacro()
 # manually.
 macro(pods_config_search_paths)
     if(NOT DEFINED __pods_setup)
-		#set where files should be output locally
-	    set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-	    set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
-	    set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
-	    set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
-		
-		#set where files should be installed to
-	    set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
-	    set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
-	    set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
-	    set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+        #set where files should be output locally
+        set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
+        set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+        set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
+        set(PKG_CONFIG_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib/pkgconfig)
+        
+        #set where files should be installed to
+        set(LIBRARY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib)
+        set(EXECUTABLE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
+        set(INCLUDE_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/include)
+        set(PKG_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 
 
         # add build/lib/pkgconfig to the pkg-config search path


### PR DESCRIPTION
This upgrades the pods.cmake files to the most recent released version (12.11.14) greatly reducing CMake warnings making it hard to read actual warnings.

Cf. before: https://travis-ci.org/ipab-slmc/pronto-distro/builds/168441345 and after https://travis-ci.org/ipab-slmc/pronto-distro/builds/181017494
