### PR TITLE
Cloud Accumulate with a buffer.

### DIFF
--- a/motion_estimate/src/cloud_accumulate/CMakeLists.txt
+++ b/motion_estimate/src/cloud_accumulate/CMakeLists.txt
@@ -4,6 +4,7 @@ project(cloud_accumulate)
 
 ################
 add_library(cloud_accumulate SHARED cloud_accumulate.cpp)
+target_link_libraries(cloud_accumulate boost_system boost_filesystem boost_thread)
 set_target_properties(cloud_accumulate PROPERTIES SOVERSION 1)
 pods_install_libraries(cloud_accumulate)
 pods_install_headers( cloud_accumulate.hpp DESTINATION cloud_accumulate)

--- a/motion_estimate/src/cloud_accumulate/cloud_accumulate.hpp
+++ b/motion_estimate/src/cloud_accumulate/cloud_accumulate.hpp
@@ -15,6 +15,8 @@
 #include <pronto_utils/pronto_vis.hpp>
 #include <pronto_utils/pronto_lcm.hpp> // decode perception lcm messages
 #include <pronto_utils/pronto_frame_check_tools.hpp>
+
+#include <boost/circular_buffer.hpp>
 ////////////////////////////////////////
 struct CloudAccumulateConfig
 {
@@ -58,7 +60,7 @@ class CloudAccumulate{
                           BotParam* botparam, BotFrames* botframes);
 
     boost::shared_ptr<lcm::LCM> lcm_;
-    const CloudAccumulateConfig& ca_cfg_;    
+    const CloudAccumulateConfig& ca_cfg_;
     
     pronto_vis* pc_vis_ ;
     BotParam* botparam_;
@@ -67,6 +69,9 @@ class CloudAccumulate{
     
     int counter_; 
     int verbose_;
+    
+    // Create a circular buffer
+    boost::circular_buffer<std::shared_ptr<bot_core::planar_lidar_t>> messages_buffer_;
     
     pronto::PointCloud* combined_cloud_;
     


### PR DESCRIPTION
The state estimate does not produce an estimate when botframes requests it, thus implementing a circular buffer with 10 messages fixes the issue.


@simalpha @mauricefallon 
![cloud_accumulate_buffer](https://cloud.githubusercontent.com/assets/1140304/22339487/0b5a89da-e3e2-11e6-9161-d3a723032fd3.png)
Blue is the cloud_accumulate output, white is the raw value in director. Currently director displays it incorrectly, but at least cloud_accumulate properly converts the scans into a point cloud.