### PR TITLE
fixes to lidar projection

### DIFF
--- a/motion_estimate/src/cloud_accumulate/cloud_accumulate.hpp
+++ b/motion_estimate/src/cloud_accumulate/cloud_accumulate.hpp
@@ -24,7 +24,6 @@ struct CloudAccumulateConfig
     std::string lidar_channel;
     double max_range;
     double min_range;
-    bool check_local_to_scan_valid;
 };
 
 class CloudAccumulate{
@@ -52,8 +51,10 @@ class CloudAccumulate{
     }
     
     void publishCloud(pronto::PointCloud* &cloud);
-    void processLidar(const bot_core::planar_lidar_t* msg);
-    void processVelodyne(const bot_core::pointcloud2_t* msg);
+
+    // returns true is scan was added, false if not
+    bool processLidar(const bot_core::planar_lidar_t* msg);
+    bool processVelodyne(const bot_core::pointcloud2_t* msg);
 
   private:
     void init(boost::shared_ptr<lcm::LCM> &lcm_, const CloudAccumulateConfig& ca_cfg_,
@@ -81,6 +82,7 @@ class CloudAccumulate{
     Laser_projector * laser_projector_;
     laser_projected_scan * projected_laser_scan_;  
     
+    // Project an individual lidar scan into the local/world frame
     pronto::PointCloud* convertPlanarScanToCloud(std::shared_ptr<bot_core::planar_lidar_t> this_msg);
     
 };

--- a/motion_estimate/src/create_octomap/create_octomap.cpp
+++ b/motion_estimate/src/create_octomap/create_octomap.cpp
@@ -206,7 +206,6 @@ int main(int argc, char ** argv) {
   ca_cfg.batch_size = 1500;
   ca_cfg.min_range = 1.85; // remove all the short range points
   ca_cfg.max_range = 30.0;
-  ca_cfg.check_local_to_scan_valid = false;
   AppConfig app_cfg;
   app_cfg.accum_at_launch = false;
   app_cfg.repeat_period = 20; // default was -1 

--- a/pronto-utils/src/pronto_joint_tools/pronto_frame_check_tools.hpp
+++ b/pronto-utils/src/pronto_joint_tools/pronto_frame_check_tools.hpp
@@ -1,27 +1,76 @@
 #ifndef __PRONTO_FRAME_CHECK_TOOLS_HPP__
 #define __PRONTO_FRAME_CHECK_TOOLS_HPP__
 
-/*
-SCAN has parent: POST_SPINDLE <fixed>
-POST_SPINDLE has parent: PRE_SPINDLE <from multisense as PRE_SPINDLE_TO_POST_SPINDLE>
-PRE_SPINDLE has parent: CAMERA_LEFT <fixed>
-CAMERA_LEFT has parent: head <fixed>
-head has parent: body  <from FK in joint2frames as BODY_TO_HEAD>
-body has parent: local <by the estimator as POSE_BODY>
-*/
-
 class FrameCheckTools
 {
 public:
   FrameCheckTools (){
-    local_to_head_frame_valid_ = false;
+    //local_to_head_frame_valid_ = false;
 
   };
   ~FrameCheckTools() {}
   
+
+  // Get the list of links between to frames e.g. from local to camera
+  std::vector < std::pair<std::string,std::string> > getPathBetweenFrames(BotFrames *botframes, 
+        std::string from_frame, std::string final_to_frame){
+    std::vector < std::pair<std::string,std::string> > chain;
+
+    while( final_to_frame != std::string( bot_frames_get_relative_to(botframes,from_frame.c_str()) ) ) {
+
+      std::string to_frame = std::string( bot_frames_get_relative_to(botframes,from_frame.c_str())) ;
+      // std::cout << "> " << from_frame << " to " << to_frame << "\n";
+
+      std::pair <std::string,std::string> link (from_frame,to_frame);   // value init
+      chain.push_back(link);
+      from_frame = to_frame;
+    }
+    std::string to_frame = std::string( bot_frames_get_relative_to(botframes,from_frame.c_str())) ;
+    std::pair <std::string,std::string> link (from_frame,to_frame);   // value init
+    chain.push_back(link);
+
+    //std::cout << "> " << from_frame << " to " << to_frame << " (last)\n";
+    //std::cout << "done\n";
   
+    return chain;
+  }
+
+  // Determine of all of the dynamic/updated frames between from_frame and to_frame
+  // have in fact been updated more recently than current_utime
+  // This is an explicit check that all frames are up-to-date
+  bool isFrameValid(BotFrames* botframes, BotParam* botparam, 
+        std::string from_frame, std::string to_frame, int64_t current_utime){
+
+    std::vector < std::pair<std::string,std::string> > chain;
+    chain = getPathBetweenFrames(botframes, from_frame, to_frame);
+
+    for (size_t i=0 ; i< chain.size() ; i++){
+      std::string key = std::string("coordinate_frames.") + chain[i].first + std::string(".updated") ;
+      bool updated = bot_param_get_boolean_or_fail(botparam, key.c_str() );
+      //std::cout << chain[i].first << " to " << chain[i].second << " "
+      //          << (updated ? "UPDATED" : "NOT UPDATED")  << " during operation\n";
+
+      if (updated){
+        int64_t last_update_utime;
+        bot_frames_get_trans_latest_timestamp(botframes, 
+             chain[i].first.c_str(), chain[i].second.c_str(), &last_update_utime);
+        if (current_utime > last_update_utime){
+          std::cout << chain[i].first << " to " << chain[i].second 
+             << " "<< last_update_utime <<" older than " << current_utime << "\n\n";
+          false;
+        }
+      }
+
+    }
+    return true;
+  }
+
+
+  // Hard-coded channel names is depreciated - now explictly check the required frames:
+  /*
   // Check if the SCAN frames have been updated at all.
   bool isLocalToScanValid(BotFrames* botframes){
+    std::cout << "isLocalToScanValid\n";
 
     if (local_to_head_frame_valid_){
       return true; 
@@ -29,12 +78,15 @@ public:
       int64_t last_update_utime_1, last_update_utime_2, last_update_utime_3;
 
       if (!bot_frames_get_trans_latest_timestamp(botframes, "PRE_SPINDLE", "POST_SPINDLE", &last_update_utime_1)){
+        std::cout << "p2p is invalid\n";
         return false; 
       }
       if (!bot_frames_get_trans_latest_timestamp(botframes, "head", "body", &last_update_utime_2)){
+        std::cout << "h2b is invalid\n";
         return false; 
       }
       if (!bot_frames_get_trans_latest_timestamp(botframes, "body", "local", &last_update_utime_3)){
+        std::cout << "b2l is invalid\n";
         return false; 
       }
       
@@ -42,6 +94,7 @@ public:
       std::cout << "head" << " to " << "body" << " last updated " << last_update_utime_2 << "\n";
       std::cout << "body" << " to " << "local" << " last updated " << last_update_utime_3 << "\n";
       
+//      if (( (last_update_utime_1 > 0) && (last_update_utime_2 > 0) )  && (last_update_utime_3 > 0) ){
       if ( (last_update_utime_1 > 0)   && (last_update_utime_3 > 0) ){
         local_to_head_frame_valid_ = true;
         return true;
@@ -65,22 +118,25 @@ public:
       return false; 
     }
     
+    std::cout << "SCAN " << scan_utime << "\n";
     std::cout << "PRE_SPINDLE" << " to " << "POST_SPINDLE" << " last updated " << last_update_utime_1 << "\n";
     std::cout << "head" << " to " << "body" << " last updated " << last_update_utime_2 << "\n";
     std::cout << "body" << " to " << "local" << " last updated " << last_update_utime_3 << "\n";
     
-    if (( (last_update_utime_1 > scan_utime) && (last_update_utime_2 > scan_utime) )  && (last_update_utime_3 > scan_utime) ){
+// one for val and one for hyq
+//    if (( (last_update_utime_1 >= scan_utime) && (last_update_utime_2 >= scan_utime) )  && (last_update_utime_3 >= scan_utime) ){
+    if (( (last_update_utime_1 >= scan_utime) && (last_update_utime_3 >= scan_utime) )){
       local_to_head_frame_valid_ = true;
       return true;
     }else{
       return false;
     }
   }  
-  
+  */
   
 private:
   
-  bool local_to_head_frame_valid_;
+  //bool local_to_head_frame_valid_;
 };
 
 


### PR DESCRIPTION
Fixes the poor method of accumulating LIDAR which checked for a hard coded set of frames in pronto_frame_check_tools.hpp.

This method now requires that all frames state if they are updated or not. Those that are updated are explicitly checked to be newer than the LIDAR timestamp

```
  body {
    relative_to = "local";
    history = 2000;
    max_frequency = 1000;
    pose_update_channel = "POSE_BODY"; 
    updated = true;    <------------------------- this is now required
    initial_transform{
      translation = [ 0, 0, 0 ];
      rpy = [0, 0, 0];
    }
  }
```

@gtinchev : I  removed the circular buffer you added. It is better suited to add this code to your application. The function processLidar now returns false when it rejects the scan. You can use this to decide to add to your circular buffer and check at a later time.
@mcamurri : this removes the issue you were having with body-to-head not being actuated on HyQ
@simalpha : this should fix the issues you have been having for a long time with incorrect scan projections.

* Tested with aicp on HyQ logs

**please report back any further issues you have with the cloud accumulator**