### PR TITLE
Build under Ubuntu 16.04

### DIFF
--- a/estimate_tools/CMakeLists.txt
+++ b/estimate_tools/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.6.0)
 
+add_definitions(-fpermissive)
+
 # pull in the pods macros. See cmake/pods.cmake for documentation
 set(POD_NAME estimate_tools)
 include(cmake/pods.cmake)

--- a/motion_estimate/CMakeLists.txt
+++ b/motion_estimate/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.6.0)
 
+add_definitions(-fpermissive)
+
 # pull in the pods macros. See cmake/pods.cmake for documentation
 set(POD_NAME motion_estimate)
 include(cmake/pods.cmake)

--- a/pronto-utils/CMakeLists.txt
+++ b/pronto-utils/CMakeLists.txt
@@ -2,6 +2,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wreturn-ty
 
 cmake_minimum_required(VERSION 2.6.0)
 
+add_definitions(-fpermissive)
+
 # pull in the pods macros. See cmake/pods.cmake for documentation
 set(POD_NAME pronto-tools)
 include(cmake/pods.cmake)

--- a/pronto-utils/src/tools/CMakeLists.txt
+++ b/pronto-utils/src/tools/CMakeLists.txt
@@ -41,7 +41,7 @@ pods_install_executables(pronto-multisense-to-frame)
 ##################################################
 pods_install_headers(conversions_lcm.hpp point_types.hpp DESTINATION pronto_utils)
 
-if(PLC_IO_FOUND)
+if(PCL_IO_FOUND)
   set(PCL_LIBRARIES  pcl_io-1.7 pcl_filters-1.7)
 elseif(PCL_IO_1_8_FOUND)
   set(PCL_LIBRARIES pcl_io-1.8 pcl_filters-1.8)

--- a/state-estimator/CMakeLists.txt
+++ b/state-estimator/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.6.0)
 
+add_definitions(-fpermissive)
+
 # pull in the pods macros. See cmake/pods.cmake for documentation
 set(POD_NAME mav_estimator)
 include(cmake/pods.cmake)

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.6.0)
 
+add_definitions(-fpermissive)
+
 file(GLOB hpp_files include/visualization/*.hpp)
 #add_definitions(-Wall -msse2 -msse3)
 


### PR DESCRIPTION
These changes were required to build with the latest master branch of LCM under Ubuntu 16.04:

- Fixing a typo when using the system install of PCL
- Adding ``-fpermissive`` in order to avoid compilation errors for casting within LCM-generated headers